### PR TITLE
Add weekly review, people radar, and follow-up engine

### DIFF
--- a/app/(dashboard)/evidence/page.tsx
+++ b/app/(dashboard)/evidence/page.tsx
@@ -312,11 +312,11 @@ export default function EvidencePage() {
             {SENTIMENTS.map(s => <option key={s} value={s}>{SENTIMENT_CONFIG[s].label}</option>)}
           </select>
 
-          <div style={{ width: "140px", flexShrink: 0 }}>
+          <div style={{ width: "160px", flexShrink: 0 }}>
             <Input type="date" value={filterFrom} onChange={e => setFilterFrom(e.target.value)} />
           </div>
           <span style={{ color: "var(--text-3)", fontSize: "var(--text-caption)", flexShrink: 0 }}>to</span>
-          <div style={{ width: "140px", flexShrink: 0 }}>
+          <div style={{ width: "160px", flexShrink: 0 }}>
             <Input type="date" value={filterTo} onChange={e => setFilterTo(e.target.value)} />
           </div>
 

--- a/app/(dashboard)/evidence/page.tsx
+++ b/app/(dashboard)/evidence/page.tsx
@@ -312,9 +312,13 @@ export default function EvidencePage() {
             {SENTIMENTS.map(s => <option key={s} value={s}>{SENTIMENT_CONFIG[s].label}</option>)}
           </select>
 
-          <Input type="date" value={filterFrom} onChange={e => setFilterFrom(e.target.value)} style={{ width: "140px" }} />
-          <span style={{ color: "var(--text-3)", fontSize: "var(--text-caption)" }}>to</span>
-          <Input type="date" value={filterTo} onChange={e => setFilterTo(e.target.value)} style={{ width: "140px" }} />
+          <div style={{ width: "140px", flexShrink: 0 }}>
+            <Input type="date" value={filterFrom} onChange={e => setFilterFrom(e.target.value)} />
+          </div>
+          <span style={{ color: "var(--text-3)", fontSize: "var(--text-caption)", flexShrink: 0 }}>to</span>
+          <div style={{ width: "140px", flexShrink: 0 }}>
+            <Input type="date" value={filterTo} onChange={e => setFilterTo(e.target.value)} />
+          </div>
 
           {activeFilters > 0 && (
             <button onClick={clearFilters} style={{ display: "inline-flex", alignItems: "center", gap: "4px", background: "none", border: "none", color: "var(--text-3)", cursor: "pointer", fontSize: "var(--text-caption)" }}>

--- a/app/(dashboard)/evidence/page.tsx
+++ b/app/(dashboard)/evidence/page.tsx
@@ -1,0 +1,409 @@
+"use client"
+
+import { useState, useEffect, useMemo } from "react"
+import { Plus, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { MarkdownTextarea } from "@/components/ui/markdown-textarea"
+import {
+  getAllEvidence,
+  createEvidence,
+  deleteEvidence,
+  type EvidenceEntry,
+  type EvidenceCategory,
+  type EvidenceSentiment,
+} from "@/lib/services/evidence"
+import { getPeople, type Person } from "@/lib/services/people"
+
+const CATEGORY_LABELS: Record<EvidenceCategory, string> = {
+  achievement:        "Achievement",
+  feedback_given:     "Feedback Given",
+  feedback_received:  "Feedback Received",
+  concern:            "Concern",
+  growth:             "Growth",
+  delivery:           "Delivery",
+  behaviour:          "Behaviour",
+  promotion_evidence: "Promotion Evidence",
+  general:            "General",
+}
+
+const CATEGORY_COLORS: Record<EvidenceCategory, { bg: string; color: string }> = {
+  achievement:        { bg: "#0d2015", color: "#4ade80" },
+  feedback_given:     { bg: "#0c1a3d", color: "#60a5fa" },
+  feedback_received:  { bg: "#1a0d2e", color: "#c084fc" },
+  concern:            { bg: "#2a0a0a", color: "#f87171" },
+  growth:             { bg: "#0d1e1e", color: "#2dd4bf" },
+  delivery:           { bg: "#0f1526", color: "#818cf8" },
+  behaviour:          { bg: "#1e1500", color: "#fbbf24" },
+  promotion_evidence: { bg: "#1e1200", color: "#f59e0b" },
+  general:            { bg: "#1a1a1a", color: "#9ca3af" },
+}
+
+const SENTIMENT_CONFIG = {
+  positive: { label: "Positive", color: "#4ade80", symbol: "↑" },
+  neutral:  { label: "Neutral",  color: "#9ca3af", symbol: "–" },
+  negative: { label: "Negative", color: "#f87171", symbol: "↓" },
+}
+
+const CATEGORIES = Object.keys(CATEGORY_LABELS) as EvidenceCategory[]
+const SENTIMENTS: EvidenceSentiment[] = ["positive", "neutral", "negative"]
+
+interface EvidenceFormState {
+  personId: string
+  category: EvidenceCategory
+  title: string
+  content: string
+  occurredAt: string
+  sentiment: EvidenceSentiment
+}
+
+const emptyForm = (): EvidenceFormState => ({
+  personId: "",
+  category: "general",
+  title: "",
+  content: "",
+  occurredAt: new Date().toISOString().split("T")[0],
+  sentiment: "neutral",
+})
+
+const thisMonth = () => {
+  const now = new Date()
+  return new Date(now.getFullYear(), now.getMonth(), 1).toISOString().split("T")[0]
+}
+
+export default function EvidencePage() {
+  const [entries, setEntries] = useState<EvidenceEntry[]>([])
+  const [people, setPeople] = useState<Person[]>([])
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState<EvidenceFormState>(emptyForm())
+  const [saving, setSaving] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  // Filters
+  const [filterPerson, setFilterPerson] = useState("")
+  const [filterCategory, setFilterCategory] = useState<EvidenceCategory | "">("")
+  const [filterSentiment, setFilterSentiment] = useState<EvidenceSentiment | "">("")
+  const [filterFrom, setFilterFrom] = useState("")
+  const [filterTo, setFilterTo] = useState("")
+
+  useEffect(() => {
+    getAllEvidence().then(setEntries).catch(console.error)
+    getPeople().then(setPeople).catch(console.error)
+  }, [])
+
+  // Stats
+  const totalEntries = entries.length
+  const entriesThisMonth = useMemo(() => {
+    const month = thisMonth()
+    return entries.filter(e => e.occurredAt >= month).length
+  }, [entries])
+
+  const categoryCounts = useMemo(() => {
+    const counts: Partial<Record<EvidenceCategory, number>> = {}
+    entries.forEach(e => { counts[e.category] = (counts[e.category] ?? 0) + 1 })
+    return counts
+  }, [entries])
+
+  // Filtered list
+  const filtered = useMemo(() => {
+    return entries.filter(e => {
+      if (filterPerson && e.personId !== filterPerson) return false
+      if (filterCategory && e.category !== filterCategory) return false
+      if (filterSentiment && e.sentiment !== filterSentiment) return false
+      if (filterFrom && e.occurredAt < filterFrom) return false
+      if (filterTo && e.occurredAt > filterTo) return false
+      return true
+    })
+  }, [entries, filterPerson, filterCategory, filterSentiment, filterFrom, filterTo])
+
+  const activeFilters = [filterPerson, filterCategory, filterSentiment, filterFrom, filterTo].filter(Boolean).length
+
+  const clearFilters = () => {
+    setFilterPerson("")
+    setFilterCategory("")
+    setFilterSentiment("")
+    setFilterFrom("")
+    setFilterTo("")
+  }
+
+  const handleSubmit = async () => {
+    if (!form.title.trim() || !form.personId) return
+    setSaving(true)
+    try {
+      const created = await createEvidence({
+        personId: form.personId,
+        category: form.category,
+        title: form.title.trim(),
+        content: form.content.trim() || null,
+        occurredAt: form.occurredAt,
+        sentiment: form.sentiment,
+        meetingId: null,
+        taskId: null,
+        includedInReview: true,
+        reviewPeriodStart: null,
+        reviewPeriodEnd: null,
+      })
+      setEntries([created, ...entries])
+      setForm(emptyForm())
+      setShowForm(false)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    setDeletingId(id)
+    try {
+      await deleteEvidence(id)
+      setEntries(entries.filter(e => e.id !== id))
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  const formatDate = (d: string) =>
+    new Date(d).toLocaleDateString("en-GB", { day: "2-digit", month: "short", year: "numeric" })
+
+  const personMap = useMemo(() => {
+    const m: Record<string, string> = {}
+    people.forEach(p => { m[p.id] = p.name })
+    return m
+  }, [people])
+
+  return (
+    <div style={{ padding: "32px" }}>
+      {/* Header */}
+      <div style={{ marginBottom: "24px", display: "flex", alignItems: "flex-start", justifyContent: "space-between" }}>
+        <div>
+          <h1>Evidence Bank</h1>
+          <p style={{ marginTop: "4px" }}>Continuous evidence log for performance reviews</p>
+        </div>
+        <button
+          onClick={() => setShowForm(true)}
+          style={{ display: "inline-flex", alignItems: "center", gap: "4px", background: "linear-gradient(90deg, #00ffe5 0%, #00f058 100%)", border: "none", color: "#0a1a0a", padding: "6px 14px", borderRadius: "4px", fontSize: "var(--text-label)", fontWeight: 600, cursor: "pointer", fontFamily: "var(--font-sans)" }}
+        >
+          <Plus style={{ width: "14px", height: "14px" }} /> Add Evidence
+        </button>
+      </div>
+
+      {/* Stats bar */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: "12px", marginBottom: "24px" }}>
+        {[
+          { label: "Total Entries", value: totalEntries },
+          { label: "This Month", value: entriesThisMonth },
+          ...CATEGORIES.filter(c => categoryCounts[c]).map(c => ({
+            label: CATEGORY_LABELS[c],
+            value: categoryCounts[c] ?? 0,
+            color: CATEGORY_COLORS[c].color,
+          })),
+        ].map((stat, i) => (
+          <div key={i} style={{ background: "var(--surf)", border: "1px solid var(--border-1)", borderRadius: "8px", padding: "16px 20px" }}>
+            <span className="form-label" style={{ display: "block" }}>{stat.label}</span>
+            <p style={{ fontSize: "24px", fontWeight: 700, color: ("color" in stat && stat.color) ? stat.color : "var(--text-1)", marginTop: "4px" }}>{stat.value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Quick-add form */}
+      {showForm && (
+        <div style={{ background: "var(--surf)", border: "1px solid var(--border-1)", borderRadius: "8px", padding: "20px 24px", marginBottom: "20px" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "16px" }}>
+            <h2>New Evidence Entry</h2>
+            <button onClick={() => { setShowForm(false); setForm(emptyForm()) }} style={{ background: "none", border: "none", color: "var(--text-3)", cursor: "pointer", padding: "4px" }}>
+              <X style={{ width: "16px", height: "16px" }} />
+            </button>
+          </div>
+          <div style={{ display: "grid", gap: "14px" }}>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 180px", gap: "12px" }}>
+              <div style={{ display: "grid", gap: "4px" }}>
+                <label className="form-label">Person *</label>
+                <select
+                  value={form.personId}
+                  onChange={e => setForm({ ...form, personId: e.target.value })}
+                  style={{ background: "var(--surf-2)", border: "1px solid var(--border-2)", borderRadius: "6px", color: form.personId ? "var(--text-1)" : "var(--text-3)", padding: "6px 10px", fontSize: "var(--text-label)", cursor: "pointer" }}
+                >
+                  <option value="">Select person...</option>
+                  {people.filter(p => p.status === "active").map(p => (
+                    <option key={p.id} value={p.id}>{p.name}</option>
+                  ))}
+                </select>
+              </div>
+              <div style={{ display: "grid", gap: "4px" }}>
+                <label className="form-label">Category</label>
+                <select
+                  value={form.category}
+                  onChange={e => setForm({ ...form, category: e.target.value as EvidenceCategory })}
+                  style={{ background: "var(--surf-2)", border: "1px solid var(--border-2)", borderRadius: "6px", color: "var(--text-1)", padding: "6px 10px", fontSize: "var(--text-label)", cursor: "pointer" }}
+                >
+                  {CATEGORIES.map(c => <option key={c} value={c}>{CATEGORY_LABELS[c]}</option>)}
+                </select>
+              </div>
+              <div style={{ display: "grid", gap: "4px" }}>
+                <label className="form-label">Date</label>
+                <Input type="date" value={form.occurredAt} onChange={e => setForm({ ...form, occurredAt: e.target.value })} />
+              </div>
+            </div>
+
+            <div style={{ display: "grid", gap: "4px" }}>
+              <label className="form-label">Title *</label>
+              <Input
+                value={form.title}
+                onChange={e => setForm({ ...form, title: e.target.value })}
+                placeholder="Brief description of the evidence..."
+              />
+            </div>
+
+            <div style={{ display: "grid", gap: "4px" }}>
+              <label className="form-label">Notes (optional)</label>
+              <MarkdownTextarea value={form.content} onValueChange={v => setForm({ ...form, content: v })} placeholder="Add context, specifics, or quotes..." rows={3} />
+            </div>
+
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                <label className="form-label" style={{ margin: 0 }}>Sentiment</label>
+                <div style={{ display: "flex", gap: "4px" }}>
+                  {SENTIMENTS.map(s => {
+                    const cfg = SENTIMENT_CONFIG[s]
+                    const active = form.sentiment === s
+                    return (
+                      <button key={s} type="button" onClick={() => setForm({ ...form, sentiment: s })}
+                        style={{ padding: "3px 10px", borderRadius: "4px", fontSize: "var(--text-label)", fontWeight: 500, cursor: "pointer", border: `1px solid ${active ? cfg.color + "60" : "var(--border-2)"}`, background: active ? cfg.color + "15" : "var(--surf-2)", color: active ? cfg.color : "var(--text-3)" }}>
+                        {cfg.symbol} {cfg.label}
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+              <div style={{ display: "flex", gap: "8px" }}>
+                <Button variant="outline" onClick={() => { setShowForm(false); setForm(emptyForm()) }}>Cancel</Button>
+                <Button onClick={handleSubmit} disabled={!form.title.trim() || !form.personId || saving}>
+                  {saving ? "Saving..." : "Save Evidence"}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Filters */}
+      <div style={{ background: "var(--surf)", border: "1px solid var(--border-1)", borderRadius: "8px", padding: "16px 20px", marginBottom: "16px" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "12px", flexWrap: "wrap" }}>
+          <span className="form-label" style={{ margin: 0, flexShrink: 0 }}>Filter</span>
+
+          <select value={filterPerson} onChange={e => setFilterPerson(e.target.value)}
+            style={{ background: "var(--surf-2)", border: "1px solid var(--border-2)", borderRadius: "6px", color: filterPerson ? "var(--text-1)" : "var(--text-3)", padding: "4px 8px", fontSize: "var(--text-label)", cursor: "pointer" }}>
+            <option value="">All people</option>
+            {people.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+          </select>
+
+          <select value={filterCategory} onChange={e => setFilterCategory(e.target.value as EvidenceCategory | "")}
+            style={{ background: "var(--surf-2)", border: "1px solid var(--border-2)", borderRadius: "6px", color: filterCategory ? "var(--text-1)" : "var(--text-3)", padding: "4px 8px", fontSize: "var(--text-label)", cursor: "pointer" }}>
+            <option value="">All categories</option>
+            {CATEGORIES.map(c => <option key={c} value={c}>{CATEGORY_LABELS[c]}</option>)}
+          </select>
+
+          <select value={filterSentiment} onChange={e => setFilterSentiment(e.target.value as EvidenceSentiment | "")}
+            style={{ background: "var(--surf-2)", border: "1px solid var(--border-2)", borderRadius: "6px", color: filterSentiment ? "var(--text-1)" : "var(--text-3)", padding: "4px 8px", fontSize: "var(--text-label)", cursor: "pointer" }}>
+            <option value="">All sentiments</option>
+            {SENTIMENTS.map(s => <option key={s} value={s}>{SENTIMENT_CONFIG[s].label}</option>)}
+          </select>
+
+          <Input type="date" value={filterFrom} onChange={e => setFilterFrom(e.target.value)} style={{ width: "140px" }} />
+          <span style={{ color: "var(--text-3)", fontSize: "var(--text-caption)" }}>to</span>
+          <Input type="date" value={filterTo} onChange={e => setFilterTo(e.target.value)} style={{ width: "140px" }} />
+
+          {activeFilters > 0 && (
+            <button onClick={clearFilters} style={{ display: "inline-flex", alignItems: "center", gap: "4px", background: "none", border: "none", color: "var(--text-3)", cursor: "pointer", fontSize: "var(--text-caption)" }}>
+              <X style={{ width: "12px", height: "12px" }} /> Clear ({activeFilters})
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Evidence list */}
+      <div style={{ background: "var(--surf)", border: "1px solid var(--border-1)", borderRadius: "8px", overflow: "hidden" }}>
+        {filtered.length === 0 ? (
+          <div style={{ padding: "48px 24px", textAlign: "center" }}>
+            <p style={{ color: "var(--text-3)", marginBottom: "12px" }}>
+              {activeFilters > 0 ? "No entries match the current filters." : "No evidence logged yet. Start capturing achievements and observations."}
+            </p>
+            {activeFilters === 0 && (
+              <Button onClick={() => setShowForm(true)}>
+                <Plus style={{ width: "14px", height: "14px" }} /> Add First Entry
+              </Button>
+            )}
+          </div>
+        ) : (
+          <>
+            <div style={{ padding: "10px 20px", borderBottom: "1px solid var(--border-1)", display: "flex", gap: "12px" }}>
+              <span className="col-header" style={{ flex: "0 0 160px" }}>Category</span>
+              <span className="col-header" style={{ flex: "0 0 160px" }}>Person</span>
+              <span className="col-header" style={{ flex: 1 }}>Evidence</span>
+              <span className="col-header" style={{ flex: "0 0 90px" }}>Sentiment</span>
+              <span className="col-header" style={{ flex: "0 0 100px", textAlign: "right" }}>Date</span>
+              <span className="col-header" style={{ flex: "0 0 60px" }}></span>
+            </div>
+            {filtered.map(entry => {
+              const cat = CATEGORY_COLORS[entry.category]
+              const sent = entry.sentiment ? SENTIMENT_CONFIG[entry.sentiment] : null
+              return (
+                <div key={entry.id}
+                  style={{ padding: "10px 20px", borderBottom: "1px solid var(--border-1)", display: "flex", gap: "12px", alignItems: "center" }}
+                  onMouseEnter={e => (e.currentTarget.style.background = "#292929")}
+                  onMouseLeave={e => (e.currentTarget.style.background = "transparent")}
+                >
+                  <div style={{ flex: "0 0 160px" }}>
+                    <span style={{ padding: "2px 7px", borderRadius: "3px", fontSize: "var(--text-caption)", fontWeight: 600, background: cat.bg, color: cat.color }}>
+                      {CATEGORY_LABELS[entry.category]}
+                    </span>
+                  </div>
+                  <div style={{ flex: "0 0 160px" }}>
+                    {entry.personName ? (
+                      <a href={`/people/${entry.personId}`} style={{ fontSize: "var(--text-label)", color: "var(--text-2)", textDecoration: "none" }}
+                        onMouseEnter={e => ((e.target as HTMLElement).style.color = "var(--text-1)")}
+                        onMouseLeave={e => ((e.target as HTMLElement).style.color = "var(--text-2)")}
+                      >{entry.personName}</a>
+                    ) : (
+                      <span style={{ fontSize: "var(--text-caption)", color: "var(--text-3)" }}>{personMap[entry.personId] ?? "Unknown"}</span>
+                    )}
+                  </div>
+                  <div style={{ flex: 1, overflow: "hidden" }}>
+                    <p style={{ fontSize: "var(--text-label)", color: "var(--text-1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", marginBottom: entry.content ? "2px" : 0 }}>{entry.title}</p>
+                    {entry.content && (
+                      <p style={{ fontSize: "var(--text-caption)", color: "var(--text-3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{entry.content}</p>
+                    )}
+                  </div>
+                  <div style={{ flex: "0 0 90px" }}>
+                    {sent && (
+                      <span style={{ fontSize: "var(--text-caption)", color: sent.color }}>{sent.symbol} {sent.label}</span>
+                    )}
+                  </div>
+                  <div style={{ flex: "0 0 100px", textAlign: "right" }}>
+                    <span style={{ fontSize: "var(--text-caption)", color: "var(--text-3)" }}>{formatDate(entry.occurredAt)}</span>
+                  </div>
+                  <div style={{ flex: "0 0 60px", display: "flex", justifyContent: "flex-end" }}>
+                    <button onClick={() => handleDelete(entry.id)} disabled={deletingId === entry.id}
+                      style={{ background: "none", border: "none", color: "var(--text-3)", cursor: deletingId === entry.id ? "not-allowed" : "pointer", padding: "4px", borderRadius: "4px", opacity: deletingId === entry.id ? 0.5 : 1 }}
+                      title="Delete entry"
+                    >
+                      <X style={{ width: "14px", height: "14px" }} />
+                    </button>
+                  </div>
+                </div>
+              )
+            })}
+            <div style={{ padding: "10px 20px", borderTop: "1px solid var(--border-1)" }}>
+              <span style={{ fontSize: "var(--text-caption)", color: "var(--text-3)" }}>
+                Showing {filtered.length} of {totalEntries} {totalEntries === 1 ? "entry" : "entries"}
+              </span>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/(dashboard)/follow-ups/page.tsx
+++ b/app/(dashboard)/follow-ups/page.tsx
@@ -2,13 +2,10 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
-import { Plus, Check, X, ExternalLink } from 'lucide-react'
+import { Plus, ExternalLink } from 'lucide-react'
 import {
   getAllFollowUps,
-  completeFollowUp,
-  cancelFollowUp,
   type FollowUp,
-  type FollowUpStatus,
 } from '@/lib/services/follow-ups'
 import { getPeople, type Person } from '@/lib/services/people'
 import { FollowUpForm } from '@/components/follow-ups/follow-up-form'
@@ -83,15 +80,6 @@ export default function FollowUpsPage() {
     ? Math.round(resolutionTimes.reduce((a, b) => a + b, 0) / resolutionTimes.length)
     : null
 
-  const handleComplete = async (id: string) => {
-    await completeFollowUp(id)
-    load()
-  }
-
-  const handleCancel = async (id: string) => {
-    await cancelFollowUp(id)
-    load()
-  }
 
   return (
     <div style={{ padding: '24px 32px', maxWidth: '900px', margin: '0 auto' }}>

--- a/app/(dashboard)/follow-ups/page.tsx
+++ b/app/(dashboard)/follow-ups/page.tsx
@@ -1,0 +1,298 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import Link from 'next/link'
+import { Plus, Check, X, ExternalLink } from 'lucide-react'
+import {
+  getAllFollowUps,
+  completeFollowUp,
+  cancelFollowUp,
+  type FollowUp,
+  type FollowUpStatus,
+} from '@/lib/services/follow-ups'
+import { getPeople, type Person } from '@/lib/services/people'
+import { FollowUpForm } from '@/components/follow-ups/follow-up-form'
+
+type ViewMode = 'active' | 'completed' | 'all'
+
+function isOverdue(fu: FollowUp): boolean {
+  if (!fu.dueDate || fu.status !== 'open') return false
+  return fu.dueDate < new Date().toISOString().split('T')[0]
+}
+
+function ageDays(dateStr: string): number {
+  return Math.floor((new Date().getTime() - new Date(dateStr).getTime()) / (24 * 60 * 60 * 1000))
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function StatusBadge({ fu }: { fu: FollowUp }) {
+  if (fu.status === 'completed') return <span style={{ fontSize: 'var(--text-caption)', fontWeight: 600, color: '#00f058', background: '#0d1f14', border: '1px solid #1a3a25', borderRadius: '4px', padding: '2px 6px' }}>Done</span>
+  if (fu.status === 'cancelled') return <span style={{ fontSize: 'var(--text-caption)', color: 'var(--text-3)', background: 'var(--surf-3)', border: '1px solid var(--border-2)', borderRadius: '4px', padding: '2px 6px' }}>Cancelled</span>
+  if (isOverdue(fu)) return <span style={{ fontSize: 'var(--text-caption)', fontWeight: 600, color: '#ff6b6b', background: '#2a0a0a', border: '1px solid #5a2020', borderRadius: '4px', padding: '2px 6px' }}>Overdue</span>
+  return <span style={{ fontSize: 'var(--text-caption)', color: 'var(--text-2)', background: 'var(--surf-3)', border: '1px solid var(--border-2)', borderRadius: '4px', padding: '2px 6px' }}>Open</span>
+}
+
+export default function FollowUpsPage() {
+  const [followUps, setFollowUps] = useState<FollowUp[]>([])
+  const [people, setPeople] = useState<Person[]>([])
+  const [loading, setLoading] = useState(true)
+  const [viewMode, setViewMode] = useState<ViewMode>('active')
+  const [personFilter, setPersonFilter] = useState<string>('all')
+  const [showOverdueOnly, setShowOverdueOnly] = useState(false)
+  const [addingFor, setAddingFor] = useState<Person | null>(null)
+  const [showPersonPicker, setShowPersonPicker] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [fus, ps] = await Promise.all([getAllFollowUps(), getPeople()])
+      setFollowUps(fus)
+      setPeople(ps.filter(p => p.status === 'active'))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  // Filtering
+  const visible = followUps.filter(fu => {
+    if (viewMode === 'active' && fu.status !== 'open') return false
+    if (viewMode === 'completed' && fu.status === 'open') return false
+    if (personFilter !== 'all' && fu.personId !== personFilter) return false
+    if (showOverdueOnly && !isOverdue(fu)) return false
+    return true
+  })
+
+  // Stats
+  const openCount = followUps.filter(f => f.status === 'open').length
+  const overdueCount = followUps.filter(f => isOverdue(f)).length
+  const completedThisMonth = followUps.filter(f => {
+    if (f.status !== 'completed' || !f.completedAt) return false
+    const d = new Date(f.completedAt)
+    const now = new Date()
+    return d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear()
+  }).length
+  const resolutionTimes = followUps
+    .filter(f => f.status === 'completed' && f.completedAt)
+    .map(f => ageDays(f.createdAt))
+  const avgResolution = resolutionTimes.length > 0
+    ? Math.round(resolutionTimes.reduce((a, b) => a + b, 0) / resolutionTimes.length)
+    : null
+
+  const handleComplete = async (id: string) => {
+    await completeFollowUp(id)
+    load()
+  }
+
+  const handleCancel = async (id: string) => {
+    await cancelFollowUp(id)
+    load()
+  }
+
+  return (
+    <div style={{ padding: '24px 32px', maxWidth: '900px', margin: '0 auto' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '20px' }}>
+        <div>
+          <h1>Follow-ups</h1>
+          <p style={{ marginTop: '4px' }}>Commitments you've made to your team</p>
+        </div>
+        <button
+          onClick={() => setShowPersonPicker(true)}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            background: 'var(--surf-3)',
+            border: '1px solid var(--border-2)',
+            borderRadius: '5px',
+            color: 'var(--text-1)',
+            fontSize: 'var(--text-meta)',
+            fontWeight: 500,
+            padding: '7px 14px',
+            cursor: 'pointer',
+            fontFamily: 'var(--font-sans)',
+          }}
+        >
+          <Plus style={{ width: '13px', height: '13px' }} /> Add follow-up
+        </button>
+      </div>
+
+      {/* Stats bar */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '10px', marginBottom: '20px' }}>
+        {[
+          { label: 'Open', value: openCount, color: 'var(--text-1)' },
+          { label: 'Overdue', value: overdueCount, color: overdueCount > 0 ? '#ff6b6b' : 'var(--text-1)' },
+          { label: 'Done this month', value: completedThisMonth, color: '#00f058' },
+          { label: 'Avg resolution', value: avgResolution !== null ? `${avgResolution}d` : '—', color: 'var(--text-2)' },
+        ].map(stat => (
+          <div key={stat.label} style={{ background: 'var(--surf)', border: '1px solid var(--border-1)', borderRadius: '6px', padding: '12px 14px' }}>
+            <div className="form-label">{stat.label}</div>
+            <div style={{ fontSize: 'var(--text-section)', fontWeight: 700, color: stat.color }}>{stat.value}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* View + filters */}
+      <div style={{ display: 'flex', gap: '8px', marginBottom: '16px', flexWrap: 'wrap', alignItems: 'center' }}>
+        {(['active', 'completed', 'all'] as ViewMode[]).map(v => (
+          <button
+            key={v}
+            onClick={() => setViewMode(v)}
+            style={{
+              background: viewMode === v ? 'var(--surf-3)' : 'var(--surf-2)',
+              border: `1px solid ${viewMode === v ? 'var(--border-3)' : 'var(--border-1)'}`,
+              borderRadius: '4px',
+              color: viewMode === v ? 'var(--text-1)' : 'var(--text-3)',
+              fontSize: 'var(--text-meta)',
+              padding: '5px 12px',
+              cursor: 'pointer',
+              fontFamily: 'var(--font-sans)',
+              textTransform: 'capitalize',
+            }}
+          >
+            {v}
+          </button>
+        ))}
+
+        <select
+          value={personFilter}
+          onChange={e => setPersonFilter(e.target.value)}
+          style={{
+            background: 'var(--surf-2)',
+            border: '1px solid var(--border-1)',
+            borderRadius: '4px',
+            color: 'var(--text-2)',
+            fontSize: 'var(--text-meta)',
+            padding: '5px 10px',
+            cursor: 'pointer',
+            fontFamily: 'var(--font-sans)',
+          }}
+        >
+          <option value="all">All people</option>
+          {people.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+        </select>
+
+        {viewMode === 'active' && (
+          <label style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: 'var(--text-meta)', color: 'var(--text-2)', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={showOverdueOnly}
+              onChange={e => setShowOverdueOnly(e.target.checked)}
+            />
+            Overdue only
+          </label>
+        )}
+      </div>
+
+      {/* Follow-up rows */}
+      {loading ? (
+        <p style={{ fontSize: 'var(--text-meta)', color: 'var(--text-3)' }}>Loading...</p>
+      ) : visible.length === 0 ? (
+        <div style={{ padding: '32px 0', textAlign: 'center' }}>
+          <p style={{ color: 'var(--text-3)', fontSize: 'var(--text-meta)' }}>
+            {viewMode === 'active' ? 'No open follow-ups. Nice work.' : 'Nothing to show.'}
+          </p>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+          {/* Column headers */}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 140px 120px 100px 120px', gap: '12px', padding: '6px 12px' }}>
+            <span className="col-header">Title</span>
+            <span className="col-header">Person</span>
+            <span className="col-header">Due / Age</span>
+            <span className="col-header">Status</span>
+            <span className="col-header">Source</span>
+          </div>
+
+          {visible.map(fu => (
+            <div
+              key={fu.id}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 140px 120px 100px 120px',
+                gap: '12px',
+                alignItems: 'center',
+                padding: '10px 12px',
+                background: isOverdue(fu) ? '#1a0a0a' : 'var(--surf)',
+                border: `1px solid ${isOverdue(fu) ? '#3a1515' : 'var(--border-1)'}`,
+                borderRadius: '5px',
+              }}
+            >
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontSize: 'var(--text-meta)', color: 'var(--text-1)', fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {fu.title}
+                </div>
+                {fu.description && (
+                  <div style={{ fontSize: 'var(--text-caption)', color: 'var(--text-3)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginTop: '2px' }}>
+                    {fu.description}
+                  </div>
+                )}
+              </div>
+
+              <div>
+                {fu.personName ? (
+                  <Link href={`/people/${fu.personId}`} style={{ fontSize: 'var(--text-meta)', color: 'var(--text-2)', textDecoration: 'none', display: 'flex', alignItems: 'center', gap: '3px' }}>
+                    {fu.personName} <ExternalLink style={{ width: '9px', height: '9px' }} />
+                  </Link>
+                ) : (
+                  <span style={{ fontSize: 'var(--text-meta)', color: 'var(--text-3)' }}>—</span>
+                )}
+              </div>
+
+              <div style={{ fontSize: 'var(--text-meta)', color: 'var(--text-3)' }}>
+                {fu.dueDate ? formatDate(fu.dueDate) : `${ageDays(fu.createdAt)}d old`}
+              </div>
+
+              <div><StatusBadge fu={fu} /></div>
+
+              <div style={{ fontSize: 'var(--text-caption)', color: 'var(--text-3)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {fu.sourceName ?? (fu.sourceType ?? '—')}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Person picker for new follow-up */}
+      {showPersonPicker && (
+        <div
+          style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}
+          onClick={() => setShowPersonPicker(false)}
+        >
+          <div
+            style={{ background: 'var(--surf-2)', border: '1px solid var(--border-2)', borderRadius: '8px', padding: '20px', width: '320px', display: 'flex', flexDirection: 'column', gap: '12px' }}
+            onClick={e => e.stopPropagation()}
+          >
+            <span style={{ fontSize: 'var(--text-body)', fontWeight: 600, color: 'var(--text-1)' }}>Who is this follow-up for?</span>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', maxHeight: '300px', overflowY: 'auto' }}>
+              {people.map(p => (
+                <button
+                  key={p.id}
+                  onClick={() => { setAddingFor(p); setShowPersonPicker(false) }}
+                  style={{ background: 'var(--surf-3)', border: '1px solid var(--border-2)', borderRadius: '4px', color: 'var(--text-1)', fontSize: 'var(--text-meta)', padding: '8px 12px', cursor: 'pointer', textAlign: 'left', fontFamily: 'var(--font-sans)' }}
+                >
+                  {p.name} {p.role && <span style={{ color: 'var(--text-3)' }}>· {p.role}</span>}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {addingFor && (
+        <FollowUpForm
+          personId={addingFor.id}
+          personName={addingFor.name}
+          sourceType="manual"
+          onSaved={() => { setAddingFor(null); load() }}
+          onCancel={() => setAddingFor(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/app/(dashboard)/meetings/page.tsx
+++ b/app/(dashboard)/meetings/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from "react"
 import { Input } from "@/components/ui/input"
-import { ChevronRight, ChevronDown, ChevronsRight, ChevronsDown } from "lucide-react"
+import { ChevronRight, ChevronDown, ChevronsRight, ChevronsDown, BookOpen } from "lucide-react"
+import { LogEvidenceModal } from "@/components/evidence/log-evidence-modal"
 import { MeetingFormDialog } from "@/components/meeting-form-dialog"
 import {
   getMeetings,
@@ -57,6 +58,7 @@ export default function MeetingsPage() {
   const [expandedTeams, setExpandedTeams] = useState<Set<string>>(new Set())
   const [leftPanelWidth, setLeftPanelWidth] = useState(220)
   const [isResizing, setIsResizing] = useState(false)
+  const [logEvidenceOpen, setLogEvidenceOpen] = useState(false)
 
   useEffect(() => {
     const loadData = async () => {
@@ -610,11 +612,23 @@ export default function MeetingsPage() {
                 {selectedMeeting.title}
               </h1>
               {/* Meta line */}
-              <p style={{ marginBottom: "16px" }}>
-                {formatDate(selectedMeeting.date)}
-                {selectedMeeting.nextMeetingDate && ` · next ${formatDate(selectedMeeting.nextMeetingDate)}`}
-                {selectedMeeting.attendees.length > 0 && ` · ${selectedMeeting.attendees.join(", ")}`}
-              </p>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px", marginBottom: "16px" }}>
+                <p>
+                  {formatDate(selectedMeeting.date)}
+                  {selectedMeeting.nextMeetingDate && ` · next ${formatDate(selectedMeeting.nextMeetingDate)}`}
+                  {selectedMeeting.attendees.length > 0 && ` · ${selectedMeeting.attendees.join(", ")}`}
+                </p>
+                {selectedMeeting.personId && (
+                  <button
+                    onClick={() => setLogEvidenceOpen(true)}
+                    style={{ display: "inline-flex", alignItems: "center", gap: "4px", padding: "4px 10px", borderRadius: "4px", fontSize: "var(--text-caption)", fontWeight: 600, color: "var(--text-2)", border: "1px solid var(--border-2)", background: "var(--surf-2)", cursor: "pointer", flexShrink: 0, fontFamily: "var(--font-sans)" }}
+                    onMouseEnter={e => ((e.currentTarget as HTMLElement).style.color = "var(--text-1)")}
+                    onMouseLeave={e => ((e.currentTarget as HTMLElement).style.color = "var(--text-2)")}
+                  >
+                    <BookOpen style={{ width: "11px", height: "11px" }} /> Log as Evidence
+                  </button>
+                )}
+              </div>
 
               {/* Meta fields grid */}
               <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px", marginBottom: "16px" }}>
@@ -762,6 +776,19 @@ export default function MeetingsPage() {
         peopleWithIds={peopleWithIds}
         teamsWithIds={teamsWithIds}
       />
+
+      {selectedMeeting?.personId && (
+        <LogEvidenceModal
+          open={logEvidenceOpen}
+          onOpenChange={setLogEvidenceOpen}
+          meetingId={selectedMeeting.id}
+          meetingTitle={selectedMeeting.title}
+          meetingDate={selectedMeeting.date}
+          personId={selectedMeeting.personId}
+          personName={selectedMeeting.personName}
+          availablePeople={peopleWithIds}
+        />
+      )}
     </div>
   )
 }

--- a/app/(dashboard)/meetings/page.tsx
+++ b/app/(dashboard)/meetings/page.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useEffect } from "react"
 import { Input } from "@/components/ui/input"
-import { ChevronRight, ChevronDown, ChevronsRight, ChevronsDown, BookOpen } from "lucide-react"
+import { ChevronRight, ChevronDown, ChevronsRight, ChevronsDown, BookOpen, ListChecks } from "lucide-react"
 import { LogEvidenceModal } from "@/components/evidence/log-evidence-modal"
+import { FollowUpForm } from "@/components/follow-ups/follow-up-form"
 import { MeetingFormDialog } from "@/components/meeting-form-dialog"
 import {
   getMeetings,
@@ -59,6 +60,7 @@ export default function MeetingsPage() {
   const [leftPanelWidth, setLeftPanelWidth] = useState(220)
   const [isResizing, setIsResizing] = useState(false)
   const [logEvidenceOpen, setLogEvidenceOpen] = useState(false)
+  const [trackFollowUpOpen, setTrackFollowUpOpen] = useState(false)
 
   useEffect(() => {
     const loadData = async () => {
@@ -619,14 +621,24 @@ export default function MeetingsPage() {
                   {selectedMeeting.attendees.length > 0 && ` · ${selectedMeeting.attendees.join(", ")}`}
                 </p>
                 {selectedMeeting.personId && (
-                  <button
-                    onClick={() => setLogEvidenceOpen(true)}
-                    style={{ display: "inline-flex", alignItems: "center", gap: "4px", padding: "4px 10px", borderRadius: "4px", fontSize: "var(--text-caption)", fontWeight: 600, color: "var(--text-2)", border: "1px solid var(--border-2)", background: "var(--surf-2)", cursor: "pointer", flexShrink: 0, fontFamily: "var(--font-sans)" }}
-                    onMouseEnter={e => ((e.currentTarget as HTMLElement).style.color = "var(--text-1)")}
-                    onMouseLeave={e => ((e.currentTarget as HTMLElement).style.color = "var(--text-2)")}
-                  >
-                    <BookOpen style={{ width: "11px", height: "11px" }} /> Log as Evidence
-                  </button>
+                  <div style={{ display: "flex", gap: "6px", flexShrink: 0 }}>
+                    <button
+                      onClick={() => setLogEvidenceOpen(true)}
+                      style={{ display: "inline-flex", alignItems: "center", gap: "4px", padding: "4px 10px", borderRadius: "4px", fontSize: "var(--text-caption)", fontWeight: 600, color: "var(--text-2)", border: "1px solid var(--border-2)", background: "var(--surf-2)", cursor: "pointer", fontFamily: "var(--font-sans)" }}
+                      onMouseEnter={e => ((e.currentTarget as HTMLElement).style.color = "var(--text-1)")}
+                      onMouseLeave={e => ((e.currentTarget as HTMLElement).style.color = "var(--text-2)")}
+                    >
+                      <BookOpen style={{ width: "11px", height: "11px" }} /> Log as Evidence
+                    </button>
+                    <button
+                      onClick={() => setTrackFollowUpOpen(true)}
+                      style={{ display: "inline-flex", alignItems: "center", gap: "4px", padding: "4px 10px", borderRadius: "4px", fontSize: "var(--text-caption)", fontWeight: 600, color: "var(--text-2)", border: "1px solid var(--border-2)", background: "var(--surf-2)", cursor: "pointer", fontFamily: "var(--font-sans)" }}
+                      onMouseEnter={e => ((e.currentTarget as HTMLElement).style.color = "var(--text-1)")}
+                      onMouseLeave={e => ((e.currentTarget as HTMLElement).style.color = "var(--text-2)")}
+                    >
+                      <ListChecks style={{ width: "11px", height: "11px" }} /> Track as Follow-up
+                    </button>
+                  </div>
                 )}
               </div>
 
@@ -787,6 +799,16 @@ export default function MeetingsPage() {
           personId={selectedMeeting.personId}
           personName={selectedMeeting.personName}
           availablePeople={peopleWithIds}
+        />
+      )}
+      {trackFollowUpOpen && selectedMeeting?.personId && (
+        <FollowUpForm
+          personId={selectedMeeting.personId}
+          personName={selectedMeeting.personName ?? 'this person'}
+          sourceType="meeting"
+          sourceId={selectedMeeting.id}
+          onSaved={() => setTrackFollowUpOpen(false)}
+          onCancel={() => setTrackFollowUpOpen(false)}
         />
       )}
     </div>

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -3,6 +3,7 @@ import { MeetingsWidget } from "@/components/dashboard/meetings-widget"
 import { TasksWidget } from "@/components/dashboard/tasks-widget"
 import { TaskPriorityChart } from "@/components/dashboard/task-priority-chart"
 import { DashboardCalendar, CalendarTask } from "@/components/dashboard/dashboard-calendar"
+import { WeeklyReviewBanner } from "@/components/dashboard/weekly-review-banner"
 
 async function getCalendarTasks(): Promise<CalendarTask[]> {
   const supabase = await createClient()
@@ -48,6 +49,9 @@ export default async function DashboardPage() {
         <h1>Dashboard</h1>
         <p style={{ marginTop: "4px" }}>{label}</p>
       </div>
+
+      {/* Weekly Review prompt */}
+      <WeeklyReviewBanner />
 
       {/* ── Widgets row ── */}
       <div className="grid grid-cols-3 gap-4">

--- a/app/(dashboard)/people/[id]/page.tsx
+++ b/app/(dashboard)/people/[id]/page.tsx
@@ -12,6 +12,7 @@ import { getPeople, updatePerson, type Person } from "@/lib/services/people"
 import { getTeams, type Team } from "@/lib/services/teams"
 import { getMeetingsForPerson, createMeeting, type MeetingType, type RecurrenceType } from "@/lib/services/meetings"
 import { LEVEL_BADGE } from "@/lib/badge-styles"
+import { EvidenceSection } from "@/components/evidence/evidence-section"
 
 interface TreeNode {
   type: string
@@ -443,6 +444,11 @@ export default function PersonDetailPage({ params }: { params: Promise<{ id: str
             )}
           </div>
         </div>
+      </div>
+
+      {/* Evidence section */}
+      <div style={{ marginTop: "24px" }}>
+        <EvidenceSection personId={personId!} personName={formData.name} />
       </div>
 
       <MeetingFormDialog

--- a/app/(dashboard)/people/[id]/page.tsx
+++ b/app/(dashboard)/people/[id]/page.tsx
@@ -349,7 +349,7 @@ export default function PersonDetailPage({ params }: { params: Promise<{ id: str
           </button>
         </div>
 
-        <div id="meetings-section" style={{ display: "flex", height: "600px", overflow: "hidden" }}>
+        <div id="meetings-section" style={{ display: "flex", height: "900px", overflow: "hidden" }}>
           {/* Left panel */}
           <div style={{ width: `${leftPanelWidth}px`, flexShrink: 0, background: "var(--surf-2)", borderRight: "1px solid var(--border-1)", overflowY: "auto" }}>
             <div style={{ padding: "8px 0" }}>

--- a/app/(dashboard)/people/[id]/page.tsx
+++ b/app/(dashboard)/people/[id]/page.tsx
@@ -13,6 +13,12 @@ import { getTeams, type Team } from "@/lib/services/teams"
 import { getMeetingsForPerson, createMeeting, type MeetingType, type RecurrenceType } from "@/lib/services/meetings"
 import { LEVEL_BADGE } from "@/lib/badge-styles"
 import { EvidenceSection } from "@/components/evidence/evidence-section"
+import { FollowUpList } from "@/components/follow-ups/follow-up-list"
+import { FollowUpForm } from "@/components/follow-ups/follow-up-form"
+import { getFollowUpsForPerson, type FollowUp } from "@/lib/services/follow-ups"
+import { usePersonSignals } from "@/lib/hooks/use-person-signals"
+import { scoreToColor, scoreToBg } from "@/lib/signals/types"
+import { AlertCircle, AlertTriangle, Info, Plus as PlusIcon } from "lucide-react"
 
 interface TreeNode {
   type: string
@@ -53,6 +59,11 @@ export default function PersonDetailPage({ params }: { params: Promise<{ id: str
   const [leftPanelWidth, setLeftPanelWidth] = useState(280)
   const [isResizing, setIsResizing] = useState(false)
 
+  const [followUps, setFollowUps] = useState<FollowUp[]>([])
+  const [addingFollowUp, setAddingFollowUp] = useState(false)
+
+  const { signals, score, loading: signalsLoading } = usePersonSignals(personId ?? '')
+
   useEffect(() => {
     params.then(({ id }) => setPersonId(id))
   }, [params])
@@ -76,6 +87,7 @@ export default function PersonDetailPage({ params }: { params: Promise<{ id: str
         personId: m.personId || undefined, teamId: m.teamId || undefined,
       })))
     }).catch(console.error)
+    getFollowUpsForPerson(personId).then(setFollowUps).catch(console.error)
   }, [personId])
 
   const tree = useMemo(() => {
@@ -228,8 +240,43 @@ export default function PersonDetailPage({ params }: { params: Promise<{ id: str
         >
           <ArrowLeft style={{ width: "14px", height: "14px" }} /> Back to People
         </button>
-        <h1>{formData.name}</h1>
-        <p style={{ marginTop: "2px" }}>{formData.role}</p>
+        <div style={{ display: "flex", alignItems: "flex-start", gap: "14px", flexWrap: "wrap" }}>
+          <div>
+            <h1>{formData.name}</h1>
+            <p style={{ marginTop: "2px" }}>{formData.role}</p>
+          </div>
+          {/* Attention indicator */}
+          {!signalsLoading && score > 0 && (
+            <div style={{ marginTop: "4px", display: "flex", flexDirection: "column", gap: "4px" }}>
+              <span style={{
+                fontSize: "var(--text-caption)",
+                fontWeight: 600,
+                color: scoreToColor(score),
+                background: scoreToBg(score),
+                border: `1px solid ${scoreToColor(score)}40`,
+                borderRadius: "4px",
+                padding: "3px 8px",
+                whiteSpace: "nowrap",
+              }}>
+                Needs attention ({score})
+              </span>
+              {signals.slice(0, 3).map((s, i) => (
+                <div key={i} style={{ display: "flex", alignItems: "center", gap: "5px" }}>
+                  {s.severity === "critical"
+                    ? <AlertCircle style={{ width: "11px", height: "11px", color: "#ff6b6b", flexShrink: 0 }} />
+                    : s.severity === "warning"
+                    ? <AlertTriangle style={{ width: "11px", height: "11px", color: "#ffa94d", flexShrink: 0 }} />
+                    : <Info style={{ width: "11px", height: "11px", color: "var(--text-3)", flexShrink: 0 }} />
+                  }
+                  <span style={{ fontSize: "var(--text-caption)", color: "var(--text-3)" }}>{s.message}</span>
+                </div>
+              ))}
+              {signals.length > 3 && (
+                <span style={{ fontSize: "var(--text-caption)", color: "var(--text-3)" }}>+{signals.length - 3} more</span>
+              )}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Profile card */}
@@ -446,10 +493,52 @@ export default function PersonDetailPage({ params }: { params: Promise<{ id: str
         </div>
       </div>
 
+      {/* Follow-ups section */}
+      <div style={{ marginTop: "24px", background: "var(--surf)", border: "1px solid var(--border-1)", borderRadius: "8px", padding: "20px" }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "14px" }}>
+          <h2 style={{ margin: 0 }}>Follow-ups</h2>
+          <button
+            onClick={() => setAddingFollowUp(true)}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "5px",
+              background: "var(--surf-3)",
+              border: "1px solid var(--border-2)",
+              borderRadius: "4px",
+              color: "var(--text-2)",
+              fontSize: "var(--text-meta)",
+              padding: "5px 10px",
+              cursor: "pointer",
+              fontFamily: "var(--font-sans)",
+            }}
+          >
+            <PlusIcon style={{ width: "11px", height: "11px" }} /> Add follow-up
+          </button>
+        </div>
+        <FollowUpList
+          followUps={followUps}
+          onChanged={() => getFollowUpsForPerson(personId!).then(setFollowUps).catch(console.error)}
+        />
+      </div>
+
       {/* Evidence section */}
       <div style={{ marginTop: "24px" }}>
         <EvidenceSection personId={personId!} personName={formData.name} />
       </div>
+
+      {addingFollowUp && personId && (
+        <FollowUpForm
+          personId={personId}
+          personName={formData.name}
+          sourceType="manual"
+          onSaved={() => {
+            setAddingFollowUp(false)
+            getFollowUpsForPerson(personId).then(setFollowUps).catch(console.error)
+          }}
+          onCancel={() => setAddingFollowUp(false)}
+        />
+      )}
 
       <MeetingFormDialog
         open={isAddMeetingDialogOpen}

--- a/app/(dashboard)/people/[id]/review/page.tsx
+++ b/app/(dashboard)/people/[id]/review/page.tsx
@@ -1,0 +1,564 @@
+"use client"
+
+import { useState, useEffect, useMemo, useCallback } from "react"
+import { useRouter } from "next/navigation"
+import { ArrowLeft, ChevronDown, ChevronRight, Printer, Plus, Save } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { MarkdownTextarea } from "@/components/ui/markdown-textarea"
+import { getPeople, type Person } from "@/lib/services/people"
+import { getMeetingsForPerson, type Meeting } from "@/lib/services/meetings"
+import {
+  getEvidenceForPersonInPeriod,
+  getReviewCycles,
+  createReviewCycle,
+  getReviewSummary,
+  upsertReviewSummary,
+  createEvidence,
+  type EvidenceEntry,
+  type EvidenceCategory,
+  type ReviewCycle,
+  type ReviewSummary,
+} from "@/lib/services/evidence"
+
+const CATEGORY_LABELS: Record<EvidenceCategory, string> = {
+  achievement:        "Achievement",
+  feedback_given:     "Feedback Given",
+  feedback_received:  "Feedback Received",
+  concern:            "Concern",
+  growth:             "Growth",
+  delivery:           "Delivery",
+  behaviour:          "Behaviour",
+  promotion_evidence: "Promotion Evidence",
+  general:            "General",
+}
+
+const CATEGORY_COLORS: Record<EvidenceCategory, { bg: string; color: string }> = {
+  achievement:        { bg: "#0d2015", color: "#4ade80" },
+  feedback_given:     { bg: "#0c1a3d", color: "#60a5fa" },
+  feedback_received:  { bg: "#1a0d2e", color: "#c084fc" },
+  concern:            { bg: "#2a0a0a", color: "#f87171" },
+  growth:             { bg: "#0d1e1e", color: "#2dd4bf" },
+  delivery:           { bg: "#0f1526", color: "#818cf8" },
+  behaviour:          { bg: "#1e1500", color: "#fbbf24" },
+  promotion_evidence: { bg: "#1e1200", color: "#f59e0b" },
+  general:            { bg: "#1a1a1a", color: "#9ca3af" },
+}
+
+const SENTIMENT_CONFIG = {
+  positive: { label: "Positive", color: "#4ade80", symbol: "↑" },
+  neutral:  { label: "Neutral",  color: "#9ca3af", symbol: "–" },
+  negative: { label: "Negative", color: "#f87171", symbol: "↓" },
+}
+
+type SectionKey = "impact" | "strengths" | "growth" | "behaviour" | "promotion" | "meetings" | "concerns" | "notes"
+
+const sixMonthsAgo = () => {
+  const d = new Date()
+  d.setMonth(d.getMonth() - 6)
+  return d.toISOString().split("T")[0]
+}
+
+const today = () => new Date().toISOString().split("T")[0]
+
+export default function ReviewPrepPage({ params }: { params: Promise<{ id: string }> }) {
+  const router = useRouter()
+  const [personId, setPersonId] = useState<string | null>(null)
+  const [person, setPerson] = useState<Person | null>(null)
+  const [evidence, setEvidence] = useState<EvidenceEntry[]>([])
+  const [meetings, setMeetings] = useState<Meeting[]>([])
+  const [reviewCycles, setReviewCycles] = useState<ReviewCycle[]>([])
+  const [selectedCycleId, setSelectedCycleId] = useState<string>("custom")
+  const [periodStart, setPeriodStart] = useState(sixMonthsAgo())
+  const [periodEnd, setPeriodEnd] = useState(today())
+  const [summary, setSummary] = useState<ReviewSummary | null>(null)
+  const [summaryText, setSummaryText] = useState("")
+  const [managerNotes, setManagerNotes] = useState("")
+  const [savingNotes, setSavingNotes] = useState(false)
+  const [collapsedSections, setCollapsedSections] = useState<Set<SectionKey>>(new Set())
+  const [showNewCycleForm, setShowNewCycleForm] = useState(false)
+  const [newCycleName, setNewCycleName] = useState("")
+  const [savingCycle, setSavingCycle] = useState(false)
+  const [savingEvidenceId, setSavingEvidenceId] = useState<string | null>(null)
+
+  useEffect(() => {
+    params.then(({ id }) => setPersonId(id))
+  }, [params])
+
+  useEffect(() => {
+    if (!personId) return
+    getPeople().then(all => {
+      const found = all.find(p => p.id === personId)
+      if (found) setPerson(found)
+    }).catch(console.error)
+    getReviewCycles().then(setReviewCycles).catch(console.error)
+    getMeetingsForPerson(personId).then(setMeetings).catch(console.error)
+  }, [personId])
+
+  const loadEvidence = useCallback(() => {
+    if (!personId) return
+    getEvidenceForPersonInPeriod(personId, periodStart, periodEnd).then(setEvidence).catch(console.error)
+  }, [personId, periodStart, periodEnd])
+
+  useEffect(() => { loadEvidence() }, [loadEvidence])
+
+  useEffect(() => {
+    if (!personId) return
+    getReviewSummary(personId, periodStart, periodEnd).then(s => {
+      setSummary(s)
+      setSummaryText(s?.summaryText ?? "")
+      setManagerNotes(s?.managerNotes ?? "")
+    }).catch(console.error)
+  }, [personId, periodStart, periodEnd])
+
+  // When a review cycle is selected, sync date range
+  useEffect(() => {
+    if (selectedCycleId === "custom") return
+    const cycle = reviewCycles.find(c => c.id === selectedCycleId)
+    if (cycle) { setPeriodStart(cycle.startDate); setPeriodEnd(cycle.endDate) }
+  }, [selectedCycleId, reviewCycles])
+
+  const handleCycleChange = (id: string) => {
+    setSelectedCycleId(id)
+    if (id === "custom") return
+    const cycle = reviewCycles.find(c => c.id === id)
+    if (cycle) { setPeriodStart(cycle.startDate); setPeriodEnd(cycle.endDate) }
+  }
+
+  const handleCreateCycle = async () => {
+    if (!newCycleName.trim()) return
+    setSavingCycle(true)
+    try {
+      const cycle = await createReviewCycle({ name: newCycleName.trim(), startDate: periodStart, endDate: periodEnd, status: "active" })
+      setReviewCycles([cycle, ...reviewCycles])
+      setSelectedCycleId(cycle.id)
+      setNewCycleName("")
+      setShowNewCycleForm(false)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSavingCycle(false)
+    }
+  }
+
+  const handleSaveNotes = async () => {
+    if (!personId) return
+    setSavingNotes(true)
+    try {
+      const saved = await upsertReviewSummary({
+        personId,
+        reviewCycleId: selectedCycleId !== "custom" ? selectedCycleId : null,
+        periodStart,
+        periodEnd,
+        summaryText: summaryText || null,
+        managerNotes: managerNotes || null,
+      })
+      setSummary(saved)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSavingNotes(false)
+    }
+  }
+
+  const handleSaveAsEvidence = async (meeting: Meeting) => {
+    if (!personId) return
+    setSavingEvidenceId(meeting.id)
+    try {
+      const created = await createEvidence({
+        personId,
+        category: "general",
+        title: meeting.title,
+        content: meeting.notes || null,
+        occurredAt: meeting.meetingDate,
+        meetingId: meeting.id,
+        taskId: null,
+        sentiment: null,
+        includedInReview: true,
+        reviewPeriodStart: periodStart,
+        reviewPeriodEnd: periodEnd,
+      })
+      setEvidence(prev => [created, ...prev])
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSavingEvidenceId(null)
+    }
+  }
+
+  const toggleSection = (key: SectionKey) => {
+    const s = new Set(collapsedSections)
+    s.has(key) ? s.delete(key) : s.add(key)
+    setCollapsedSections(s)
+  }
+
+  // Period-filtered meetings
+  const periodMeetings = useMemo(() =>
+    meetings.filter(m => m.meetingDate >= periodStart && m.meetingDate <= periodEnd)
+      .sort((a, b) => new Date(b.meetingDate).getTime() - new Date(a.meetingDate).getTime()),
+    [meetings, periodStart, periodEnd]
+  )
+
+  // Evidence grouped by section
+  const impactEntries = useMemo(() =>
+    evidence.filter(e => ["achievement", "delivery"].includes(e.category) && e.includedInReview),
+    [evidence])
+
+  const strengthsEntries = useMemo(() =>
+    evidence.filter(e =>
+      (["feedback_given", "feedback_received", "behaviour"].includes(e.category) && e.sentiment === "positive") && e.includedInReview),
+    [evidence])
+
+  const growthEntries = useMemo(() =>
+    evidence.filter(e =>
+      (["growth"].includes(e.category) ||
+        (["feedback_given"].includes(e.category) && (e.sentiment === "negative" || e.sentiment === "neutral")) ||
+        e.category === "concern") && e.includedInReview),
+    [evidence])
+
+  const behaviourEntries = useMemo(() =>
+    evidence.filter(e => e.category === "behaviour" && e.includedInReview),
+    [evidence])
+
+  const promotionEntries = useMemo(() =>
+    evidence.filter(e => e.category === "promotion_evidence" && e.includedInReview),
+    [evidence])
+
+  const concernEntries = useMemo(() =>
+    evidence.filter(e => e.category === "concern" && e.includedInReview),
+    [evidence])
+
+  const formatDate = (d: string) =>
+    new Date(d).toLocaleDateString("en-GB", { day: "2-digit", month: "short", year: "numeric" })
+
+  const handlePrint = () => window.print()
+
+  if (!person) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100%" }}>
+        <p>Loading...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ padding: "32px", maxWidth: "900px" }} className="review-prep-page">
+      {/* Header */}
+      <div style={{ marginBottom: "24px" }}>
+        <button
+          onClick={() => router.push(`/people/${personId}`)}
+          style={{ display: "inline-flex", alignItems: "center", gap: "6px", background: "none", border: "none", color: "var(--text-2)", cursor: "pointer", fontSize: "var(--text-label)", marginBottom: "16px", padding: "4px 0" }}
+          onMouseEnter={e => (e.currentTarget.style.color = "var(--text-1)")}
+          onMouseLeave={e => (e.currentTarget.style.color = "var(--text-2)")}
+        >
+          <ArrowLeft style={{ width: "14px", height: "14px" }} /> Back to {person.name}
+        </button>
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between" }}>
+          <div>
+            <h1>Review Prep — {person.name}</h1>
+            <p style={{ marginTop: "4px" }}>{person.role}</p>
+          </div>
+          <div style={{ display: "flex", gap: "8px" }}>
+            <Button variant="outline" onClick={handlePrint}>
+              <Printer style={{ width: "14px", height: "14px" }} /> Export
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Period selector */}
+      <div style={{ background: "var(--surf)", border: "1px solid var(--border-1)", borderRadius: "8px", padding: "16px 20px", marginBottom: "20px" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "16px", flexWrap: "wrap" }}>
+          <div style={{ display: "grid", gap: "4px" }}>
+            <label className="form-label">Review Cycle</label>
+            <select value={selectedCycleId} onChange={e => handleCycleChange(e.target.value)}
+              style={{ background: "var(--surf-2)", border: "1px solid var(--border-2)", borderRadius: "6px", color: "var(--text-1)", padding: "6px 10px", fontSize: "var(--text-label)", cursor: "pointer" }}>
+              <option value="custom">Custom range</option>
+              {reviewCycles.map(c => (
+                <option key={c.id} value={c.id}>{c.name} ({formatDate(c.startDate)} – {formatDate(c.endDate)})</option>
+              ))}
+            </select>
+          </div>
+          <div style={{ display: "grid", gap: "4px" }}>
+            <label className="form-label">From</label>
+            <Input type="date" value={periodStart} onChange={e => { setPeriodStart(e.target.value); setSelectedCycleId("custom") }} style={{ width: "150px" }} />
+          </div>
+          <div style={{ display: "grid", gap: "4px" }}>
+            <label className="form-label">To</label>
+            <Input type="date" value={periodEnd} onChange={e => { setPeriodEnd(e.target.value); setSelectedCycleId("custom") }} style={{ width: "150px" }} />
+          </div>
+          <div style={{ paddingTop: "18px" }}>
+            <button onClick={() => setShowNewCycleForm(!showNewCycleForm)}
+              style={{ display: "inline-flex", alignItems: "center", gap: "4px", background: "none", border: "1px solid var(--border-2)", color: "var(--text-2)", padding: "6px 10px", borderRadius: "4px", fontSize: "var(--text-caption)", cursor: "pointer" }}>
+              <Plus style={{ width: "12px", height: "12px" }} /> Save as cycle
+            </button>
+          </div>
+        </div>
+        {showNewCycleForm && (
+          <div style={{ display: "flex", gap: "8px", alignItems: "flex-end", marginTop: "12px", paddingTop: "12px", borderTop: "1px solid var(--border-1)" }}>
+            <div style={{ display: "grid", gap: "4px", flex: 1 }}>
+              <label className="form-label">Cycle name</label>
+              <Input value={newCycleName} onChange={e => setNewCycleName(e.target.value)} placeholder="e.g. H1 2026, Annual 2025" />
+            </div>
+            <Button onClick={handleCreateCycle} disabled={!newCycleName.trim() || savingCycle}>
+              {savingCycle ? "Saving..." : "Save Cycle"}
+            </Button>
+            <Button variant="outline" onClick={() => setShowNewCycleForm(false)}>Cancel</Button>
+          </div>
+        )}
+        <div style={{ marginTop: "12px", paddingTop: "12px", borderTop: "1px solid var(--border-1)", display: "flex", gap: "24px" }}>
+          <span style={{ fontSize: "var(--text-caption)", color: "var(--text-3)" }}>
+            {evidence.length} evidence {evidence.length === 1 ? "entry" : "entries"} in period
+          </span>
+          <span style={{ fontSize: "var(--text-caption)", color: "var(--text-3)" }}>
+            {periodMeetings.length} {periodMeetings.length === 1 ? "meeting" : "meetings"} in period
+          </span>
+        </div>
+      </div>
+
+      {/* Summary */}
+      <ReviewSection
+        title="Summary"
+        sectionKey="impact"
+        collapsed={collapsedSections.has("impact")}
+        onToggle={() => toggleSection("impact")}
+        count={summaryText ? 1 : 0}
+        emptyMessage="Write a synthesis of this person's performance for the review period. Capture the overall narrative before diving into specifics."
+      >
+        <MarkdownTextarea
+          value={summaryText}
+          onValueChange={setSummaryText}
+          placeholder="Write a high-level summary of performance during this period..."
+          rows={6}
+        />
+      </ReviewSection>
+
+      {/* Impact & Delivery */}
+      <ReviewSection
+        title="Impact & Delivery"
+        sectionKey="impact"
+        collapsed={collapsedSections.has("impact")}
+        onToggle={() => toggleSection("impact")}
+        count={impactEntries.length}
+        emptyMessage="No delivery evidence logged yet. Add evidence from the person's profile or tag meeting notes as evidence."
+      >
+        {impactEntries.map(e => (
+          <EvidenceCard key={e.id} entry={e} formatDate={formatDate} />
+        ))}
+      </ReviewSection>
+
+      {/* Strengths */}
+      <ReviewSection
+        title="Strengths"
+        sectionKey="strengths"
+        collapsed={collapsedSections.has("strengths")}
+        onToggle={() => toggleSection("strengths")}
+        count={strengthsEntries.length}
+        emptyMessage="No strengths evidence logged. Consider noting positive feedback and strong behavioural examples from your 1:1s."
+      >
+        {strengthsEntries.map(e => (
+          <EvidenceCard key={e.id} entry={e} formatDate={formatDate} />
+        ))}
+      </ReviewSection>
+
+      {/* Growth Areas */}
+      <ReviewSection
+        title="Growth Areas"
+        sectionKey="growth"
+        collapsed={collapsedSections.has("growth")}
+        onToggle={() => toggleSection("growth")}
+        count={growthEntries.length}
+        emptyMessage="No growth evidence logged. Note development discussions from 1:1s and areas where improvement would be impactful."
+      >
+        {growthEntries.map(e => (
+          <EvidenceCard key={e.id} entry={e} formatDate={formatDate} />
+        ))}
+      </ReviewSection>
+
+      {/* Behavioural Examples */}
+      <ReviewSection
+        title="Behavioural Examples"
+        sectionKey="behaviour"
+        collapsed={collapsedSections.has("behaviour")}
+        onToggle={() => toggleSection("behaviour")}
+        count={behaviourEntries.length}
+        emptyMessage="No behavioural examples logged."
+      >
+        {behaviourEntries.map(e => (
+          <EvidenceCard key={e.id} entry={e} formatDate={formatDate} />
+        ))}
+      </ReviewSection>
+
+      {/* Promotion Evidence — only show if entries exist */}
+      {promotionEntries.length > 0 && (
+        <ReviewSection
+          title="Promotion Evidence"
+          sectionKey="promotion"
+          collapsed={collapsedSections.has("promotion")}
+          onToggle={() => toggleSection("promotion")}
+          count={promotionEntries.length}
+          emptyMessage=""
+        >
+          {promotionEntries.map(e => (
+            <EvidenceCard key={e.id} entry={e} formatDate={formatDate} />
+          ))}
+        </ReviewSection>
+      )}
+
+      {/* Open Concerns */}
+      <ReviewSection
+        title="Open Concerns"
+        sectionKey="concerns"
+        collapsed={collapsedSections.has("concerns")}
+        onToggle={() => toggleSection("concerns")}
+        count={concernEntries.length}
+        emptyMessage="No concerns logged."
+      >
+        {concernEntries.map(e => (
+          <EvidenceCard key={e.id} entry={e} formatDate={formatDate} />
+        ))}
+      </ReviewSection>
+
+      {/* Meeting History */}
+      <ReviewSection
+        title="Meeting History"
+        sectionKey="meetings"
+        collapsed={collapsedSections.has("meetings")}
+        onToggle={() => toggleSection("meetings")}
+        count={periodMeetings.length}
+        emptyMessage="No meetings found in this period."
+      >
+        {periodMeetings.map(m => (
+          <div key={m.id} style={{ padding: "12px 16px", border: "1px solid var(--border-1)", borderRadius: "6px", marginBottom: "8px", background: "var(--surf-2)" }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px" }}>
+              <div>
+                <p style={{ fontSize: "var(--text-label)", color: "var(--text-1)", fontWeight: 500 }}>{m.title}</p>
+                <p style={{ fontSize: "var(--text-caption)", color: "var(--text-3)", marginTop: "2px" }}>
+                  {m.meetingType} · {formatDate(m.meetingDate)}
+                </p>
+                {m.notes && (
+                  <p style={{ fontSize: "var(--text-caption)", color: "var(--text-2)", marginTop: "6px", overflow: "hidden", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical" }}>
+                    {m.notes.replace(/<[^>]*>/g, "")}
+                  </p>
+                )}
+              </div>
+              <button
+                onClick={() => handleSaveAsEvidence(m)}
+                disabled={savingEvidenceId === m.id}
+                style={{ flexShrink: 0, display: "inline-flex", alignItems: "center", gap: "4px", padding: "4px 10px", borderRadius: "4px", fontSize: "var(--text-caption)", border: "1px solid var(--border-2)", background: "var(--surf)", color: "var(--text-2)", cursor: savingEvidenceId === m.id ? "not-allowed" : "pointer", opacity: savingEvidenceId === m.id ? 0.6 : 1 }}
+              >
+                <Plus style={{ width: "11px", height: "11px" }} />
+                {savingEvidenceId === m.id ? "Saving..." : "Save as evidence"}
+              </button>
+            </div>
+          </div>
+        ))}
+      </ReviewSection>
+
+      {/* Manager Notes */}
+      <ReviewSection
+        title="Manager Notes"
+        sectionKey="notes"
+        collapsed={collapsedSections.has("notes")}
+        onToggle={() => toggleSection("notes")}
+        count={managerNotes ? 1 : 0}
+        emptyMessage="Private notes for your own reference during the review conversation."
+      >
+        <MarkdownTextarea
+          value={managerNotes}
+          onValueChange={setManagerNotes}
+          placeholder="Private notes for the review conversation (not included in exports)..."
+          rows={4}
+        />
+      </ReviewSection>
+
+      {/* Save notes */}
+      <div style={{ display: "flex", justifyContent: "flex-end", gap: "8px", marginTop: "24px", paddingTop: "16px", borderTop: "1px solid var(--border-1)" }}>
+        <Button onClick={handleSaveNotes} disabled={savingNotes}>
+          <Save style={{ width: "14px", height: "14px" }} />
+          {savingNotes ? "Saving..." : "Save Notes"}
+        </Button>
+      </div>
+
+      {/* Print styles */}
+      <style>{`
+        @media print {
+          .review-prep-page button,
+          .review-prep-page [role="button"] { display: none !important; }
+          .no-print { display: none !important; }
+          body { background: white; color: black; }
+        }
+      `}</style>
+    </div>
+  )
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function ReviewSection({
+  title, sectionKey, collapsed, onToggle, count, emptyMessage, children,
+}: {
+  title: string
+  sectionKey: SectionKey
+  collapsed: boolean
+  onToggle: () => void
+  count: number
+  emptyMessage: string
+  children?: React.ReactNode
+}) {
+  return (
+    <div style={{ background: "var(--surf)", border: "1px solid var(--border-1)", borderRadius: "8px", overflow: "hidden", marginBottom: "12px" }}>
+      <button
+        onClick={onToggle}
+        style={{ width: "100%", padding: "14px 20px", display: "flex", alignItems: "center", gap: "8px", background: "none", border: "none", cursor: "pointer", textAlign: "left" }}
+        onMouseEnter={e => ((e.currentTarget as HTMLElement).style.background = "var(--surf-2)")}
+        onMouseLeave={e => ((e.currentTarget as HTMLElement).style.background = "none")}
+      >
+        {collapsed
+          ? <ChevronRight style={{ width: "14px", height: "14px", color: "var(--text-3)", flexShrink: 0 }} />
+          : <ChevronDown style={{ width: "14px", height: "14px", color: "var(--text-3)", flexShrink: 0 }} />}
+        <h2 style={{ flex: 1 }}>{title}</h2>
+        <span style={{ fontSize: "var(--text-caption)", color: "var(--text-3)" }}>{count} {count === 1 ? "entry" : "entries"}</span>
+      </button>
+      {!collapsed && (
+        <div style={{ padding: "4px 20px 20px" }}>
+          {count === 0 && emptyMessage ? (
+            <p style={{ fontSize: "var(--text-label)", color: "var(--text-3)", fontStyle: "italic", paddingTop: "8px" }}>{emptyMessage}</p>
+          ) : children}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function EvidenceCard({ entry, formatDate }: { entry: EvidenceEntry; formatDate: (d: string) => string }) {
+  const cat = CATEGORY_COLORS[entry.category]
+  const sent = entry.sentiment ? SENTIMENT_CONFIG[entry.sentiment] : null
+
+  return (
+    <div style={{ padding: "12px 16px", border: "1px solid var(--border-1)", borderRadius: "6px", marginBottom: "8px", background: "var(--surf-2)" }}>
+      <div style={{ display: "flex", alignItems: "flex-start", gap: "10px" }}>
+        <span style={{ padding: "2px 7px", borderRadius: "3px", fontSize: "var(--text-caption)", fontWeight: 600, background: cat.bg, color: cat.color, flexShrink: 0, marginTop: "2px" }}>
+          {CATEGORY_LABELS[entry.category]}
+        </span>
+        <div style={{ flex: 1 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: entry.content ? "6px" : 0 }}>
+            <p style={{ fontSize: "var(--text-label)", color: "var(--text-1)", fontWeight: 500, flex: 1 }}>{entry.title}</p>
+            {sent && (
+              <span style={{ fontSize: "var(--text-caption)", color: sent.color, flexShrink: 0 }}>{sent.symbol} {sent.label}</span>
+            )}
+            <span style={{ fontSize: "var(--text-caption)", color: "var(--text-3)", flexShrink: 0 }}>{formatDate(entry.occurredAt)}</span>
+          </div>
+          {entry.content && (
+            <p style={{ fontSize: "var(--text-caption)", color: "var(--text-2)", whiteSpace: "pre-wrap" }}>{entry.content}</p>
+          )}
+          {entry.meetingTitle && (
+            <p style={{ fontSize: "var(--text-caption)", color: "#60a5fa", marginTop: "4px" }}>
+              Meeting: {entry.meetingTitle}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/(dashboard)/people/[id]/review/page.tsx
+++ b/app/(dashboard)/people/[id]/review/page.tsx
@@ -18,7 +18,6 @@ import {
   type EvidenceEntry,
   type EvidenceCategory,
   type ReviewCycle,
-  type ReviewSummary,
 } from "@/lib/services/evidence"
 
 const CATEGORY_LABELS: Record<EvidenceCategory, string> = {
@@ -71,7 +70,6 @@ export default function ReviewPrepPage({ params }: { params: Promise<{ id: strin
   const [selectedCycleId, setSelectedCycleId] = useState<string>("custom")
   const [periodStart, setPeriodStart] = useState(sixMonthsAgo())
   const [periodEnd, setPeriodEnd] = useState(today())
-  const [summary, setSummary] = useState<ReviewSummary | null>(null)
   const [summaryText, setSummaryText] = useState("")
   const [managerNotes, setManagerNotes] = useState("")
   const [savingNotes, setSavingNotes] = useState(false)
@@ -105,7 +103,6 @@ export default function ReviewPrepPage({ params }: { params: Promise<{ id: strin
   useEffect(() => {
     if (!personId) return
     getReviewSummary(personId, periodStart, periodEnd).then(s => {
-      setSummary(s)
       setSummaryText(s?.summaryText ?? "")
       setManagerNotes(s?.managerNotes ?? "")
     }).catch(console.error)
@@ -145,7 +142,7 @@ export default function ReviewPrepPage({ params }: { params: Promise<{ id: strin
     if (!personId) return
     setSavingNotes(true)
     try {
-      const saved = await upsertReviewSummary({
+      await upsertReviewSummary({
         personId,
         reviewCycleId: selectedCycleId !== "custom" ? selectedCycleId : null,
         periodStart,
@@ -153,7 +150,6 @@ export default function ReviewPrepPage({ params }: { params: Promise<{ id: strin
         summaryText: summaryText || null,
         managerNotes: managerNotes || null,
       })
-      setSummary(saved)
     } catch (err) {
       console.error(err)
     } finally {
@@ -496,10 +492,10 @@ export default function ReviewPrepPage({ params }: { params: Promise<{ id: strin
 // ── Sub-components ────────────────────────────────────────────────────────────
 
 function ReviewSection({
-  title, sectionKey, collapsed, onToggle, count, emptyMessage, children,
+  title, collapsed, onToggle, count, emptyMessage, children,
 }: {
   title: string
-  sectionKey: SectionKey
+  sectionKey?: SectionKey
   collapsed: boolean
   onToggle: () => void
   count: number

--- a/app/(dashboard)/people/page.tsx
+++ b/app/(dashboard)/people/page.tsx
@@ -7,6 +7,7 @@ import { PeopleTable } from "@/components/people-table"
 import { DeleteConfirmDialog } from "@/components/delete-confirm-dialog"
 import { getPeople, createPerson, updatePerson, deletePerson as deletePersonService, togglePersonStatus, type Person } from "@/lib/services/people"
 import { getTeams, type Team } from "@/lib/services/teams"
+import { useRadar } from "@/lib/hooks/use-person-signals"
 
 const byName = <T extends { name: string }>(arr: T[]) =>
   [...arr].sort((a, b) => a.name.localeCompare(b.name))
@@ -19,6 +20,11 @@ export default function PeoplePage() {
   const [editingPerson, setEditingPerson] = useState<Person | null>(null)
   const [deletingPerson, setDeletingPerson] = useState<Person | null>(null)
   const [, setIsLoading] = useState(true)
+
+  const { people: radarPeople } = useRadar()
+  const attentionScores: Record<string, number> = Object.fromEntries(
+    radarPeople.map(p => [p.personId, p.score])
+  )
 
   useEffect(() => {
     loadPeople()
@@ -172,6 +178,7 @@ export default function PeoplePage() {
           onDelete={(person) => setDeletingPerson(person)}
           onToggleStatus={handleToggleStatus}
           onQuickAdd={() => setIsAddDialogOpen(true)}
+          attentionScores={attentionScores}
         />
       </div>
 

--- a/app/(dashboard)/radar/page.tsx
+++ b/app/(dashboard)/radar/page.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import {
-  AlertCircle, AlertTriangle, Info, User, ChevronDown, ChevronRight, Plus,
+  AlertCircle, AlertTriangle, Info, ChevronDown, ChevronRight, Plus,
   CheckCircle, ExternalLink
 } from 'lucide-react'
 import { useRadar, type PersonAttention } from '@/lib/hooks/use-person-signals'
@@ -12,7 +12,7 @@ import { completeFollowUp, getFollowUpsForPerson, markFollowUpsSurfaced, type Fo
 import { updateTask } from '@/lib/services/tasks'
 import { FollowUpForm } from '@/components/follow-ups/follow-up-form'
 import { FollowUpList } from '@/components/follow-ups/follow-up-list'
-import { scoreToColor, scoreToBg, computeAttentionScore } from '@/lib/signals/types'
+import { scoreToColor, scoreToBg } from '@/lib/signals/types'
 import type { Signal } from '@/lib/signals/types'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -256,7 +256,6 @@ function PersonCard({
 export default function RadarPage() {
   const { people, loading, error, refetch } = useRadar()
   const [severityFilter, setSeverityFilter] = useState<SeverityFilter>('all')
-  const [teamFilter, setTeamFilter] = useState<string>('all')
   const [showAllClear, setShowAllClear] = useState(false)
 
   const needsAttention = people.filter(p => p.score > 0)

--- a/app/(dashboard)/radar/page.tsx
+++ b/app/(dashboard)/radar/page.tsx
@@ -1,0 +1,404 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import {
+  AlertCircle, AlertTriangle, Info, User, ChevronDown, ChevronRight, Plus,
+  CheckCircle, ExternalLink
+} from 'lucide-react'
+import { useRadar, type PersonAttention } from '@/lib/hooks/use-person-signals'
+import { completeFollowUp, getFollowUpsForPerson, markFollowUpsSurfaced, type FollowUp } from '@/lib/services/follow-ups'
+import { updateTask } from '@/lib/services/tasks'
+import { FollowUpForm } from '@/components/follow-ups/follow-up-form'
+import { FollowUpList } from '@/components/follow-ups/follow-up-list'
+import { scoreToColor, scoreToBg, computeAttentionScore } from '@/lib/signals/types'
+import type { Signal } from '@/lib/signals/types'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function SeverityIcon({ severity }: { severity: Signal['severity'] }) {
+  if (severity === 'critical') return <AlertCircle style={{ width: '12px', height: '12px', color: '#ff6b6b', flexShrink: 0 }} />
+  if (severity === 'warning') return <AlertTriangle style={{ width: '12px', height: '12px', color: '#ffa94d', flexShrink: 0 }} />
+  return <Info style={{ width: '12px', height: '12px', color: 'var(--text-3)', flexShrink: 0 }} />
+}
+
+function ScoreBadge({ score }: { score: number }) {
+  const color = scoreToColor(score)
+  const bg = scoreToBg(score)
+  return (
+    <span style={{
+      fontSize: 'var(--text-caption)',
+      fontWeight: 700,
+      color,
+      background: bg,
+      border: `1px solid ${color}40`,
+      borderRadius: '4px',
+      padding: '2px 8px',
+      fontVariantNumeric: 'tabular-nums',
+    }}>
+      {score}
+    </span>
+  )
+}
+
+// ── Attention filter ──────────────────────────────────────────────────────────
+
+type SeverityFilter = 'all' | 'critical' | 'warning'
+
+function matchesSeverityFilter(pa: PersonAttention, filter: SeverityFilter): boolean {
+  if (filter === 'all') return true
+  return pa.signals.some(s => s.severity === filter)
+}
+
+// ── Person attention card ─────────────────────────────────────────────────────
+
+function PersonCard({
+  pa,
+  onRefresh,
+}: {
+  pa: PersonAttention
+  onRefresh: () => void
+}) {
+  const router = useRouter()
+  const [showFollowUps, setShowFollowUps] = useState(false)
+  const [followUps, setFollowUps] = useState<FollowUp[]>([])
+  const [loadingFollowUps, setLoadingFollowUps] = useState(false)
+  const [addingFollowUp, setAddingFollowUp] = useState(false)
+
+  const loadFollowUps = useCallback(async () => {
+    setLoadingFollowUps(true)
+    try {
+      const data = await getFollowUpsForPerson(pa.personId)
+      setFollowUps(data)
+      // Mark any open follow-ups as surfaced
+      const open = data.filter(f => f.status === 'open')
+      if (open.length > 0) {
+        await markFollowUpsSurfaced(open.map(f => ({ id: f.id, timesSurfaced: f.timesSurfaced })))
+      }
+    } finally {
+      setLoadingFollowUps(false)
+    }
+  }, [pa.personId])
+
+  const toggleFollowUps = () => {
+    if (!showFollowUps && followUps.length === 0) loadFollowUps()
+    setShowFollowUps(s => !s)
+  }
+
+  const handleMarkTaskDone = async (taskId: string) => {
+    await updateTask(taskId, { status: 'Done' })
+    onRefresh()
+  }
+
+  return (
+    <div style={{
+      background: 'var(--surf)',
+      border: '1px solid var(--border-1)',
+      borderRadius: '8px',
+      overflow: 'hidden',
+    }}>
+      {/* Card header */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: '12px',
+        padding: '14px 16px',
+        background: 'var(--surf-2)',
+        borderBottom: '1px solid var(--border-1)',
+      }}>
+        <div style={{
+          width: '32px',
+          height: '32px',
+          borderRadius: '50%',
+          background: 'var(--surf-3)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 'var(--text-meta)',
+          fontWeight: 600,
+          color: 'var(--text-2)',
+          flexShrink: 0,
+        }}>
+          {pa.personName.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2)}
+        </div>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <Link
+              href={`/people/${pa.personId}`}
+              style={{ fontSize: 'var(--text-body)', fontWeight: 600, color: 'var(--text-1)', textDecoration: 'none', display: 'flex', alignItems: 'center', gap: '4px' }}
+            >
+              {pa.personName}
+              <ExternalLink style={{ width: '10px', height: '10px', color: 'var(--text-3)' }} />
+            </Link>
+            <ScoreBadge score={pa.score} />
+          </div>
+          {pa.personRole && (
+            <div style={{ fontSize: 'var(--text-meta)', color: 'var(--text-2)', marginTop: '2px' }}>{pa.personRole}</div>
+          )}
+        </div>
+
+        <div style={{ display: 'flex', gap: '6px', flexShrink: 0 }}>
+          <button
+            onClick={() => router.push(`/meetings?new=1&type=1:1&personId=${pa.personId}`)}
+            style={{ background: 'var(--surf-3)', border: '1px solid var(--border-2)', borderRadius: '4px', color: 'var(--text-2)', fontSize: 'var(--text-caption)', padding: '4px 8px', cursor: 'pointer', whiteSpace: 'nowrap', fontFamily: 'var(--font-sans)' }}
+          >
+            Schedule 1:1
+          </button>
+          <button
+            onClick={() => router.push(`/evidence?new=1&personId=${pa.personId}`)}
+            style={{ background: 'var(--surf-3)', border: '1px solid var(--border-2)', borderRadius: '4px', color: 'var(--text-2)', fontSize: 'var(--text-caption)', padding: '4px 8px', cursor: 'pointer', whiteSpace: 'nowrap', fontFamily: 'var(--font-sans)' }}
+          >
+            Log evidence
+          </button>
+          <button
+            onClick={() => setAddingFollowUp(true)}
+            style={{ background: 'var(--surf-3)', border: '1px solid var(--border-2)', borderRadius: '4px', color: 'var(--text-2)', fontSize: 'var(--text-caption)', padding: '4px 8px', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '3px', fontFamily: 'var(--font-sans)' }}
+          >
+            <Plus style={{ width: '10px', height: '10px' }} /> Follow-up
+          </button>
+        </div>
+      </div>
+
+      {/* Signals list */}
+      {pa.signals.length > 0 && (
+        <div>
+          {pa.signals.map((signal, i) => (
+            <div
+              key={i}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                padding: '8px 16px',
+                borderBottom: '1px solid var(--border-1)',
+                fontSize: 'var(--text-meta)',
+              }}
+            >
+              <SeverityIcon severity={signal.severity} />
+              <span style={{ flex: 1, color: 'var(--text-2)' }}>{signal.message}</span>
+              {/* Quick actions per signal type */}
+              {signal.type === 'overdue_task' && (
+                <button
+                  onClick={() => handleMarkTaskDone(signal.entityId)}
+                  style={{ background: 'none', border: '1px solid var(--border-2)', borderRadius: '4px', color: 'var(--text-3)', fontSize: 'var(--text-caption)', padding: '2px 8px', cursor: 'pointer', whiteSpace: 'nowrap' }}
+                >
+                  Mark done
+                </button>
+              )}
+              {(signal.type === 'overdue_follow_up' || signal.type === 'ageing_follow_up' || signal.type === 'surfaced_follow_up') && (
+                <button
+                  onClick={async () => { await completeFollowUp(signal.entityId); onRefresh() }}
+                  style={{ background: 'none', border: '1px solid var(--border-2)', borderRadius: '4px', color: '#00f058', fontSize: 'var(--text-caption)', padding: '2px 8px', cursor: 'pointer', whiteSpace: 'nowrap' }}
+                >
+                  Complete
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Follow-ups section */}
+      {pa.openFollowUpCount > 0 && (
+        <div style={{ borderTop: pa.signals.length > 0 ? 'none' : '1px solid var(--border-1)' }}>
+          <button
+            onClick={toggleFollowUps}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6px',
+              width: '100%',
+              padding: '8px 16px',
+              background: 'none',
+              border: 'none',
+              borderTop: '1px solid var(--border-1)',
+              color: 'var(--text-3)',
+              fontSize: 'var(--text-caption)',
+              cursor: 'pointer',
+              fontFamily: 'var(--font-sans)',
+              textAlign: 'left',
+            }}
+          >
+            {showFollowUps ? <ChevronDown style={{ width: '11px', height: '11px' }} /> : <ChevronRight style={{ width: '11px', height: '11px' }} />}
+            {pa.openFollowUpCount} open follow-up{pa.openFollowUpCount !== 1 ? 's' : ''}
+          </button>
+
+          {showFollowUps && (
+            <div style={{ padding: '4px 16px 12px' }}>
+              {loadingFollowUps ? (
+                <p style={{ fontSize: 'var(--text-meta)', color: 'var(--text-3)' }}>Loading...</p>
+              ) : (
+                <FollowUpList followUps={followUps} onChanged={() => { loadFollowUps(); onRefresh() }} />
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Add follow-up form */}
+      {addingFollowUp && (
+        <FollowUpForm
+          personId={pa.personId}
+          personName={pa.personName}
+          sourceType="manual"
+          onSaved={() => { setAddingFollowUp(false); loadFollowUps(); onRefresh() }}
+          onCancel={() => setAddingFollowUp(false)}
+        />
+      )}
+    </div>
+  )
+}
+
+// ── Radar page ────────────────────────────────────────────────────────────────
+
+export default function RadarPage() {
+  const { people, loading, error, refetch } = useRadar()
+  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>('all')
+  const [teamFilter, setTeamFilter] = useState<string>('all')
+  const [showAllClear, setShowAllClear] = useState(false)
+
+  const needsAttention = people.filter(p => p.score > 0)
+  const allClear = people.filter(p => p.score === 0)
+
+  const filtered = needsAttention
+    .filter(p => matchesSeverityFilter(p, severityFilter))
+
+  const criticalCount = people.filter(p => p.signals.some(s => s.severity === 'critical')).length
+
+  if (loading) {
+    return (
+      <div style={{ padding: '32px', color: 'var(--text-2)', fontSize: 'var(--text-meta)' }}>
+        Computing attention signals...
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: '32px' }}>
+        <p style={{ color: '#ff6b6b', fontSize: 'var(--text-meta)' }}>{error}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ padding: '24px 32px', maxWidth: '860px', margin: '0 auto' }}>
+      {/* Header */}
+      <div style={{ marginBottom: '20px' }}>
+        <h1>People Radar</h1>
+        <p style={{ marginTop: '4px' }}>
+          {needsAttention.length > 0
+            ? `${needsAttention.length} person${needsAttention.length !== 1 ? 's' : ''} need${needsAttention.length === 1 ? 's' : ''} attention`
+            : 'All clear — everyone is on track'}
+        </p>
+      </div>
+
+      {/* Quick stats */}
+      {needsAttention.length > 0 && (
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '20px', flexWrap: 'wrap' }}>
+          <div style={{ background: '#2a0a0a', border: '1px solid #5a2020', borderRadius: '6px', padding: '10px 16px', minWidth: '100px' }}>
+            <div style={{ fontSize: 'var(--text-overline)', color: 'var(--text-3)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: '2px' }}>Critical</div>
+            <div style={{ fontSize: 'var(--text-section)', fontWeight: 700, color: '#ff6b6b' }}>{criticalCount}</div>
+          </div>
+          <div style={{ background: 'var(--surf)', border: '1px solid var(--border-1)', borderRadius: '6px', padding: '10px 16px', minWidth: '100px' }}>
+            <div style={{ fontSize: 'var(--text-overline)', color: 'var(--text-3)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: '2px' }}>Needs attention</div>
+            <div style={{ fontSize: 'var(--text-section)', fontWeight: 700, color: 'var(--text-1)' }}>{needsAttention.length}</div>
+          </div>
+          <div style={{ background: '#0d1f14', border: '1px solid #1a3a25', borderRadius: '6px', padding: '10px 16px', minWidth: '100px' }}>
+            <div style={{ fontSize: 'var(--text-overline)', color: 'var(--text-3)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: '2px' }}>All clear</div>
+            <div style={{ fontSize: 'var(--text-section)', fontWeight: 700, color: '#00f058' }}>{allClear.length}</div>
+          </div>
+        </div>
+      )}
+
+      {/* Filters */}
+      {needsAttention.length > 0 && (
+        <div style={{ display: 'flex', gap: '8px', marginBottom: '20px', flexWrap: 'wrap' }}>
+          {(['all', 'critical', 'warning'] as SeverityFilter[]).map(f => (
+            <button
+              key={f}
+              onClick={() => setSeverityFilter(f)}
+              style={{
+                background: severityFilter === f ? 'var(--surf-3)' : 'var(--surf-2)',
+                border: `1px solid ${severityFilter === f ? 'var(--border-3)' : 'var(--border-1)'}`,
+                borderRadius: '4px',
+                color: severityFilter === f ? 'var(--text-1)' : 'var(--text-3)',
+                fontSize: 'var(--text-meta)',
+                padding: '5px 12px',
+                cursor: 'pointer',
+                fontFamily: 'var(--font-sans)',
+                textTransform: 'capitalize',
+              }}
+            >
+              {f === 'all' ? 'All signals' : f}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Person cards */}
+      {filtered.length === 0 && needsAttention.length > 0 && (
+        <p style={{ fontSize: 'var(--text-meta)', color: 'var(--text-3)' }}>No people match this filter.</p>
+      )}
+
+      {people.length === 0 && (
+        <div style={{ textAlign: 'center', padding: '48px 0' }}>
+          <p style={{ color: 'var(--text-2)', marginBottom: '12px' }}>No active team members yet.</p>
+          <Link href="/people" style={{ color: '#00f058', fontSize: 'var(--text-meta)', textDecoration: 'none' }}>
+            Add your team →
+          </Link>
+        </div>
+      )}
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+        {filtered.map(pa => (
+          <PersonCard key={pa.personId} pa={pa} onRefresh={refetch} />
+        ))}
+      </div>
+
+      {/* All clear section */}
+      {allClear.length > 0 && (
+        <div style={{ marginTop: '20px', borderTop: '1px solid var(--border-1)', paddingTop: '16px' }}>
+          <button
+            onClick={() => setShowAllClear(s => !s)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6px',
+              background: 'none',
+              border: 'none',
+              color: 'var(--text-3)',
+              fontSize: 'var(--text-meta)',
+              cursor: 'pointer',
+              fontFamily: 'var(--font-sans)',
+              padding: 0,
+              marginBottom: '10px',
+            }}
+          >
+            {showAllClear ? <ChevronDown style={{ width: '13px', height: '13px' }} /> : <ChevronRight style={{ width: '13px', height: '13px' }} />}
+            <CheckCircle style={{ width: '13px', height: '13px', color: '#00f058' }} />
+            People with no signals ({allClear.length})
+          </button>
+
+          {showAllClear && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+              {allClear.map(pa => (
+                <div key={pa.personId} style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '6px 10px', background: 'var(--surf-2)', borderRadius: '5px' }}>
+                  <div style={{ width: '6px', height: '6px', borderRadius: '50%', background: '#00f058', flexShrink: 0 }} />
+                  <Link href={`/people/${pa.personId}`} style={{ fontSize: 'var(--text-meta)', color: 'var(--text-2)', textDecoration: 'none' }}>
+                    {pa.personName}
+                  </Link>
+                  {pa.personRole && (
+                    <span style={{ fontSize: 'var(--text-caption)', color: 'var(--text-3)' }}>{pa.personRole}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/(dashboard)/review/page.tsx
+++ b/app/(dashboard)/review/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import {
   ChevronLeft, ChevronRight, AlertCircle, AlertTriangle, Info,
-  CheckCircle, Clock, Calendar, User, ExternalLink
+  CheckCircle, User, ExternalLink
 } from 'lucide-react'
 import { createClient } from '@/lib/supabase/client'
 import {
@@ -211,7 +211,7 @@ export default function WeeklyReviewPage() {
   }, [weekStart])
 
   // Signals
-  const { signals, loading: signalsLoading, refetch: refetchSignals } = useWeeklyReviewSignals(dismissed)
+  const { signals, refetch: refetchSignals } = useWeeklyReviewSignals(dismissed)
 
   // Auto-save notes on blur / debounce
   const handleNotesChange = (val: string) => {
@@ -532,7 +532,7 @@ export default function WeeklyReviewPage() {
                 onDismiss={setDismissTarget}
                 actions={
                   <div style={{ display: 'flex', gap: '6px' }}>
-                    {s.meta?.taskId && (
+                    {Boolean(s.meta?.taskId) && (
                       <ActionBtn onClick={() => handleMarkTaskDone(s.meta!.taskId as string)}>
                         Mark done
                       </ActionBtn>

--- a/app/(dashboard)/review/page.tsx
+++ b/app/(dashboard)/review/page.tsx
@@ -1,0 +1,801 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import {
+  ChevronLeft, ChevronRight, AlertCircle, AlertTriangle, Info,
+  CheckCircle, Clock, Calendar, User, ExternalLink
+} from 'lucide-react'
+import { createClient } from '@/lib/supabase/client'
+import {
+  getMondayOfWeek,
+  formatWeekRange,
+  getOrCreateWeeklyReview,
+  getWeeklyReview,
+  getDismissedItems,
+  dismissItem,
+  updateReviewNotes,
+  completeWeeklyReview,
+  reopenWeeklyReview,
+  type WeeklyReview,
+  type DismissedItem,
+  type ReviewSnapshot,
+} from '@/lib/services/weekly-review'
+import { useWeeklyReviewSignals, type ReviewSignal, type SignalSeverity } from '@/lib/hooks/use-weekly-review-signals'
+import { ReviewSection } from '@/components/review/review-section'
+import { DismissDialog } from '@/components/review/dismiss-dialog'
+import { updateTask } from '@/lib/services/tasks'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function addDays(dateStr: string, n: number): string {
+  const d = new Date(dateStr + 'T00:00:00')
+  d.setDate(d.getDate() + n)
+  return d.toISOString().split('T')[0]
+}
+
+function severityIcon(severity: SignalSeverity) {
+  if (severity === 'critical') return <AlertCircle style={{ width: '13px', height: '13px', color: '#ff6b6b', flexShrink: 0 }} />
+  if (severity === 'warning') return <AlertTriangle style={{ width: '13px', height: '13px', color: '#ffa94d', flexShrink: 0 }} />
+  return <Info style={{ width: '13px', height: '13px', color: 'var(--text-3)', flexShrink: 0 }} />
+}
+
+function severityColor(severity: SignalSeverity): string {
+  if (severity === 'critical') return '#ff6b6b'
+  if (severity === 'warning') return '#ffa94d'
+  return 'var(--text-2)'
+}
+
+// ── Signal row component ──────────────────────────────────────────────────────
+
+function SignalRow({
+  signal,
+  onDismiss,
+  actions,
+}: {
+  signal: ReviewSignal
+  onDismiss: (signal: ReviewSignal) => void
+  actions?: React.ReactNode
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '10px',
+        padding: '10px 16px',
+        borderBottom: '1px solid var(--border-1)',
+        fontSize: 'var(--text-meta)',
+      }}
+    >
+      {severityIcon(signal.severity)}
+      <span style={{ flex: 1, color: severityColor(signal.severity) }}>{signal.message}</span>
+      {actions}
+      <button
+        onClick={() => onDismiss(signal)}
+        style={{
+          background: 'none',
+          border: '1px solid var(--border-2)',
+          borderRadius: '4px',
+          color: 'var(--text-3)',
+          fontSize: 'var(--text-caption)',
+          padding: '3px 8px',
+          cursor: 'pointer',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        Dismiss
+      </button>
+    </div>
+  )
+}
+
+// ── Action button ─────────────────────────────────────────────────────────────
+
+function ActionBtn({ onClick, children }: { onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        background: 'var(--surf-3)',
+        border: '1px solid var(--border-2)',
+        borderRadius: '4px',
+        color: 'var(--text-1)',
+        fontSize: 'var(--text-caption)',
+        padding: '3px 8px',
+        cursor: 'pointer',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function WeeklyReviewPage() {
+  const router = useRouter()
+
+  // Week navigation
+  const [weekStart, setWeekStart] = useState<string>(getMondayOfWeek())
+  const isCurrentWeek = weekStart === getMondayOfWeek()
+
+  // Review state
+  const [review, setReview] = useState<WeeklyReview | null>(null)
+  const [dismissed, setDismissed] = useState<DismissedItem[]>([])
+  const [loadingReview, setLoadingReview] = useState(true)
+
+  // Section reviewed state
+  const [sectionState, setSectionState] = useState<Record<string, boolean>>({
+    people: false,
+    actions: false,
+    tasks: false,
+    week: false,
+    reflection: false,
+  })
+
+  // Reflection notes
+  const [notes, setNotes] = useState('')
+  const notesDebounce = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Dismiss dialog
+  const [dismissTarget, setDismissTarget] = useState<ReviewSignal | null>(null)
+
+  // Activity summary state
+  const [activitySummary, setActivitySummary] = useState<{
+    meetingsHeld: { id: string; title: string }[]
+    tasksCompleted: { id: string; title: string }[]
+    evidenceLogged: number
+    actionItemsCreated: number
+  } | null>(null)
+
+  // Completing state
+  const [completing, setCompleting] = useState(false)
+
+  // Load review + dismissed items
+  const loadReview = useCallback(async () => {
+    setLoadingReview(true)
+    try {
+      let r: WeeklyReview
+      if (isCurrentWeek) {
+        r = await getOrCreateWeeklyReview(weekStart)
+      } else {
+        const existing = await getWeeklyReview(weekStart)
+        if (!existing) {
+          setReview(null)
+          setDismissed([])
+          setLoadingReview(false)
+          return
+        }
+        r = existing
+      }
+      setReview(r)
+      setNotes(r.notes ?? '')
+      const items = await getDismissedItems(r.id)
+      setDismissed(items)
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setLoadingReview(false)
+    }
+  }, [weekStart, isCurrentWeek])
+
+  useEffect(() => { loadReview() }, [loadReview])
+
+  // Load activity summary
+  useEffect(() => {
+    async function loadActivity() {
+      const supabase = createClient()
+      const weekEnd = addDays(weekStart, 6)
+      const [
+        { data: meetings },
+        { data: tasks },
+        { data: evidence },
+        { data: actionItems },
+      ] = await Promise.all([
+        supabase.from('meetings').select('id, title').gte('meeting_date', weekStart).lte('meeting_date', weekEnd),
+        supabase.from('tasks').select('id, title').eq('status', 'completed').gte('completion_date', weekStart).lte('completion_date', weekEnd),
+        supabase.from('evidence_entries').select('id').gte('occurred_at', weekStart).lte('occurred_at', weekEnd),
+        supabase.from('tasks').select('id').eq('source', 'meeting_action').gte('created_at', weekStart + 'T00:00:00').lte('created_at', weekEnd + 'T23:59:59'),
+      ])
+      setActivitySummary({
+        meetingsHeld: (meetings ?? []).map(m => ({ id: m.id, title: m.title })),
+        tasksCompleted: (tasks ?? []).map(t => ({ id: t.id, title: t.title })),
+        evidenceLogged: (evidence ?? []).length,
+        actionItemsCreated: (actionItems ?? []).length,
+      })
+    }
+    loadActivity()
+  }, [weekStart])
+
+  // Signals
+  const { signals, loading: signalsLoading, refetch: refetchSignals } = useWeeklyReviewSignals(dismissed)
+
+  // Auto-save notes on blur / debounce
+  const handleNotesChange = (val: string) => {
+    setNotes(val)
+    if (!review) return
+    if (notesDebounce.current) clearTimeout(notesDebounce.current)
+    notesDebounce.current = setTimeout(() => {
+      updateReviewNotes(review.id, val).catch(console.error)
+    }, 1000)
+  }
+
+  // Dismiss a signal
+  const handleDismiss = async (signal: ReviewSignal, note: string) => {
+    if (!review) return
+    const item = await dismissItem(
+      review.id,
+      signal.type,
+      signal.entityId,
+      signal.entityType,
+      note
+    )
+    setDismissed(d => [...d, item])
+    setDismissTarget(null)
+    refetchSignals()
+  }
+
+  // Mark task done from review
+  const handleMarkTaskDone = async (taskId: string) => {
+    await updateTask(taskId, { status: 'Done' })
+    refetchSignals()
+  }
+
+  // Shift task by 7 days
+  const handleMoveTaskNextWeek = async (taskId: string, currentDueDate: string) => {
+    const newDate = addDays(currentDueDate, 7)
+    await updateTask(taskId, { dueDate: newDate })
+    refetchSignals()
+  }
+
+  // Section toggle
+  const toggleSection = (key: string) => {
+    setSectionState(s => ({ ...s, [key]: !s[key] }))
+  }
+
+  // Complete the review
+  const handleComplete = async () => {
+    if (!review) return
+    setCompleting(true)
+    try {
+      const snapshot: ReviewSnapshot = {
+        overdueTasks: signals.filter(s => s.type === 'overdue_task').length,
+        noRecent1on1: signals.filter(s => s.type === 'no_recent_1on1').length,
+        unresolvedActions: signals.filter(s => s.type === 'unresolved_action').length,
+        noEvidence: signals.filter(s => s.type === 'no_evidence').length,
+        upcomingDeadlines: signals.filter(s => s.type === 'upcoming_deadline').length,
+        missingNotes: signals.filter(s => s.type === 'missing_notes').length,
+        totalSignals: signals.length,
+        criticalSignals: signals.filter(s => s.severity === 'critical').length,
+        warningSignals: signals.filter(s => s.severity === 'warning').length,
+      }
+      const updated = await completeWeeklyReview(review.id, snapshot)
+      setReview(updated)
+    } finally {
+      setCompleting(false)
+    }
+  }
+
+  const handleReopen = async () => {
+    if (!review) return
+    const updated = await reopenWeeklyReview(review.id)
+    setReview(updated)
+  }
+
+  // Week navigation
+  const goToPrevWeek = () => setWeekStart(addDays(weekStart, -7))
+  const goToNextWeek = () => setWeekStart(addDays(weekStart, 7))
+  const goToCurrentWeek = () => setWeekStart(getMondayOfWeek())
+
+  // Signal bucketing
+  const peopleSignals = signals.filter(s =>
+    s.type === 'no_recent_1on1' || s.type === 'no_evidence' || s.type === 'missing_notes'
+  )
+  const actionSignals = signals.filter(s => s.type === 'unresolved_action')
+  const taskSignals = signals.filter(s => s.type === 'overdue_task' || s.type === 'upcoming_deadline')
+  const overdueSignals = taskSignals.filter(s => s.type === 'overdue_task')
+  const upcomingSignals = taskSignals.filter(s => s.type === 'upcoming_deadline')
+
+  // Progress
+  const totalSections = 5
+  const reviewedCount = Object.values(sectionState).filter(Boolean).length
+  const progressPct = Math.round((reviewedCount / totalSections) * 100)
+
+  const isReadOnly = !isCurrentWeek && review?.status === 'completed'
+  const isCompleted = review?.status === 'completed'
+
+  if (loadingReview) {
+    return (
+      <div style={{ padding: '32px', color: 'var(--text-2)', fontSize: 'var(--text-meta)' }}>
+        Loading weekly review...
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ padding: '24px 32px', maxWidth: '860px', margin: '0 auto' }}>
+
+      {/* Header */}
+      <div style={{ marginBottom: '24px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '8px' }}>
+          <h1 style={{ margin: 0 }}>Weekly Review</h1>
+
+          {/* Status badge */}
+          {isCompleted ? (
+            <span style={{
+              fontSize: 'var(--text-caption)',
+              fontWeight: 600,
+              background: '#0f2a1a',
+              color: '#00f058',
+              border: '1px solid #1a4a2a',
+              borderRadius: '4px',
+              padding: '3px 8px',
+            }}>
+              Completed ✓
+            </span>
+          ) : (
+            <span style={{
+              fontSize: 'var(--text-caption)',
+              fontWeight: 600,
+              background: 'var(--surf-3)',
+              color: 'var(--text-2)',
+              border: '1px solid var(--border-2)',
+              borderRadius: '4px',
+              padding: '3px 8px',
+            }}>
+              In Progress
+            </span>
+          )}
+        </div>
+
+        {/* Week navigation */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <button
+            onClick={goToPrevWeek}
+            style={{ background: 'none', border: 'none', color: 'var(--text-3)', cursor: 'pointer', display: 'flex', padding: '4px' }}
+          >
+            <ChevronLeft style={{ width: '16px', height: '16px' }} />
+          </button>
+
+          <span style={{ fontSize: 'var(--text-body)', color: 'var(--text-2)', fontWeight: 500 }}>
+            {formatWeekRange(weekStart)}
+          </span>
+
+          <button
+            onClick={goToNextWeek}
+            style={{ background: 'none', border: 'none', color: 'var(--text-3)', cursor: 'pointer', display: 'flex', padding: '4px' }}
+          >
+            <ChevronRight style={{ width: '16px', height: '16px' }} />
+          </button>
+
+          {!isCurrentWeek && (
+            <button
+              onClick={goToCurrentWeek}
+              style={{
+                background: 'var(--surf-3)',
+                border: '1px solid var(--border-2)',
+                borderRadius: '4px',
+                color: 'var(--text-2)',
+                fontSize: 'var(--text-meta)',
+                padding: '4px 10px',
+                cursor: 'pointer',
+              }}
+            >
+              This week
+            </button>
+          )}
+
+          {isCompleted && review?.completedAt && (
+            <span style={{ fontSize: 'var(--text-meta)', color: 'var(--text-3)', marginLeft: 'auto' }}>
+              Completed {new Date(review.completedAt).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}
+            </span>
+          )}
+        </div>
+
+        {/* Past week — no review */}
+        {!isCurrentWeek && !review && (
+          <p style={{ marginTop: '32px', fontSize: 'var(--text-meta)', color: 'var(--text-3)' }}>
+            No review was recorded for this week.
+          </p>
+        )}
+      </div>
+
+      {/* Progress bar (current week only) */}
+      {isCurrentWeek && (
+        <div style={{ marginBottom: '24px' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '6px' }}>
+            <span style={{ fontSize: 'var(--text-meta)', color: 'var(--text-3)' }}>
+              {reviewedCount} of {totalSections} sections reviewed
+            </span>
+            <span style={{ fontSize: 'var(--text-meta)', color: 'var(--text-3)' }}>{progressPct}%</span>
+          </div>
+          <div style={{ height: '4px', background: 'var(--surf-3)', borderRadius: '2px', overflow: 'hidden' }}>
+            <div style={{
+              height: '100%',
+              width: `${progressPct}%`,
+              background: 'linear-gradient(90deg, #00ffe5, #00f058)',
+              borderRadius: '2px',
+              transition: 'width 0.3s ease',
+            }} />
+          </div>
+        </div>
+      )}
+
+      {/* Show snapshot summary for past completed reviews */}
+      {isReadOnly && review?.snapshot && (
+        <div style={{
+          background: 'var(--surf)',
+          border: '1px solid var(--border-1)',
+          borderRadius: '8px',
+          padding: '16px',
+          marginBottom: '20px',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 1fr)',
+          gap: '12px',
+        }}>
+          {[
+            { label: 'Overdue tasks', value: review.snapshot.overdueTasks },
+            { label: 'No recent 1:1', value: review.snapshot.noRecent1on1 },
+            { label: 'Unresolved actions', value: review.snapshot.unresolvedActions },
+            { label: 'No evidence', value: review.snapshot.noEvidence },
+            { label: 'Upcoming deadlines', value: review.snapshot.upcomingDeadlines },
+            { label: 'Missing notes', value: review.snapshot.missingNotes },
+          ].map(stat => (
+            <div key={stat.label}>
+              <div style={{ fontSize: 'var(--text-overline)', color: 'var(--text-3)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: '2px' }}>
+                {stat.label}
+              </div>
+              <div style={{ fontSize: 'var(--text-section)', fontWeight: 600, color: 'var(--text-1)' }}>
+                {stat.value}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {(review || isCurrentWeek) && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+
+          {/* Section 1: People Check */}
+          <ReviewSection
+            title="People Check"
+            signalCount={isReadOnly ? 0 : peopleSignals.length}
+            criticalCount={isReadOnly ? 0 : peopleSignals.filter(s => s.severity === 'critical').length}
+            warningCount={isReadOnly ? 0 : peopleSignals.filter(s => s.severity === 'warning').length}
+            isReviewed={sectionState.people}
+            onMarkReviewed={() => toggleSection('people')}
+            emptyMessage="All clear — everyone has been seen recently ✓"
+          >
+            {!isReadOnly && (() => {
+              const byPerson: Record<string, { name: string; signals: ReviewSignal[] }> = {}
+              for (const s of peopleSignals) {
+                if (!s.personId) continue
+                if (!byPerson[s.personId]) byPerson[s.personId] = { name: s.personName ?? s.personId, signals: [] }
+                byPerson[s.personId].signals.push(s)
+              }
+              return Object.entries(byPerson).map(([personId, { name, signals: pSignals }]) => (
+                <div key={personId}>
+                  <div style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    padding: '8px 16px',
+                    background: 'var(--surf-2)',
+                    borderBottom: '1px solid var(--border-1)',
+                  }}>
+                    <User style={{ width: '12px', height: '12px', color: 'var(--text-3)' }} />
+                    <Link
+                      href={`/people/${personId}`}
+                      style={{ fontSize: 'var(--text-meta)', fontWeight: 600, color: 'var(--text-1)', textDecoration: 'none', display: 'flex', alignItems: 'center', gap: '4px' }}
+                    >
+                      {name}
+                      <ExternalLink style={{ width: '10px', height: '10px', color: 'var(--text-3)' }} />
+                    </Link>
+                    <div style={{ marginLeft: 'auto', display: 'flex', gap: '6px' }}>
+                      <ActionBtn onClick={() => router.push(`/meetings?new=1&type=1:1&personId=${personId}`)}>
+                        Schedule 1:1
+                      </ActionBtn>
+                      <ActionBtn onClick={() => router.push(`/evidence?new=1&personId=${personId}`)}>
+                        Log note
+                      </ActionBtn>
+                    </div>
+                  </div>
+                  {pSignals.map((s, i) => (
+                    <SignalRow
+                      key={i}
+                      signal={s}
+                      onDismiss={setDismissTarget}
+                    />
+                  ))}
+                </div>
+              ))
+            })()}
+          </ReviewSection>
+
+          {/* Section 2: Action Items */}
+          <ReviewSection
+            title="Action Items & Follow-ups"
+            signalCount={isReadOnly ? 0 : actionSignals.length}
+            criticalCount={isReadOnly ? 0 : actionSignals.filter(s => s.severity === 'critical').length}
+            warningCount={isReadOnly ? 0 : actionSignals.filter(s => s.severity === 'warning').length}
+            isReviewed={sectionState.actions}
+            onMarkReviewed={() => toggleSection('actions')}
+            emptyMessage="All action items resolved ✓"
+          >
+            {!isReadOnly && actionSignals.map((s, i) => (
+              <SignalRow
+                key={i}
+                signal={s}
+                onDismiss={setDismissTarget}
+                actions={
+                  <div style={{ display: 'flex', gap: '6px' }}>
+                    {s.meta?.taskId && (
+                      <ActionBtn onClick={() => handleMarkTaskDone(s.meta!.taskId as string)}>
+                        Mark done
+                      </ActionBtn>
+                    )}
+                    <Link
+                      href={`/meetings/${s.entityId}`}
+                      style={{ textDecoration: 'none' }}
+                    >
+                      <ActionBtn onClick={() => {}}>View meeting</ActionBtn>
+                    </Link>
+                  </div>
+                }
+              />
+            ))}
+          </ReviewSection>
+
+          {/* Section 3: Tasks & Deadlines */}
+          <ReviewSection
+            title="Tasks & Deadlines"
+            signalCount={isReadOnly ? 0 : taskSignals.length}
+            criticalCount={isReadOnly ? 0 : overdueSignals.filter(s => s.severity === 'critical').length}
+            warningCount={isReadOnly ? 0 : overdueSignals.filter(s => s.severity === 'warning').length}
+            isReviewed={sectionState.tasks}
+            onMarkReviewed={() => toggleSection('tasks')}
+            emptyMessage="No overdue tasks and no deadlines this week ✓"
+          >
+            {!isReadOnly && (
+              <>
+                {overdueSignals.length > 0 && (
+                  <>
+                    <div style={{ padding: '8px 16px', background: 'var(--surf-2)', borderBottom: '1px solid var(--border-1)' }}>
+                      <span style={{ fontSize: 'var(--text-meta)', fontWeight: 600, color: '#ff6b6b' }}>Overdue</span>
+                    </div>
+                    {overdueSignals.map((s, i) => (
+                      <SignalRow
+                        key={i}
+                        signal={s}
+                        onDismiss={setDismissTarget}
+                        actions={
+                          <div style={{ display: 'flex', gap: '6px' }}>
+                            <ActionBtn onClick={() => handleMarkTaskDone(s.entityId)}>Mark done</ActionBtn>
+                            <ActionBtn onClick={() => handleMoveTaskNextWeek(s.entityId, s.meta?.dueDate as string)}>
+                              +7 days
+                            </ActionBtn>
+                          </div>
+                        }
+                      />
+                    ))}
+                  </>
+                )}
+                {upcomingSignals.length > 0 && (
+                  <>
+                    <div style={{ padding: '8px 16px', background: 'var(--surf-2)', borderBottom: '1px solid var(--border-1)' }}>
+                      <span style={{ fontSize: 'var(--text-meta)', fontWeight: 600, color: 'var(--text-2)' }}>Due this week</span>
+                    </div>
+                    {upcomingSignals.map((s, i) => (
+                      <SignalRow
+                        key={i}
+                        signal={s}
+                        onDismiss={setDismissTarget}
+                        actions={
+                          <ActionBtn onClick={() => handleMarkTaskDone(s.entityId)}>Mark done</ActionBtn>
+                        }
+                      />
+                    ))}
+                  </>
+                )}
+              </>
+            )}
+          </ReviewSection>
+
+          {/* Section 4: Week in Review */}
+          <ReviewSection
+            title="Week in Review — What Happened"
+            signalCount={0}
+            isReviewed={sectionState.week}
+            onMarkReviewed={() => toggleSection('week')}
+            emptyMessage=""
+          >
+            {null}
+          </ReviewSection>
+
+          {/* Activity summary rendered outside ReviewSection emptyMessage */}
+          {(() => {
+            if (!activitySummary) return null
+            return (
+              <div style={{
+                background: 'var(--surf)',
+                border: '1px solid var(--border-1)',
+                borderRadius: '8px',
+                padding: '16px',
+                marginTop: '-12px',
+                display: 'grid',
+                gridTemplateColumns: 'repeat(2, 1fr)',
+                gap: '16px',
+              }}>
+                <div>
+                  <div className="form-label">Meetings held</div>
+                  <div style={{ fontSize: 'var(--text-section)', fontWeight: 600, color: 'var(--text-1)', marginBottom: '8px' }}>
+                    {activitySummary.meetingsHeld.length}
+                  </div>
+                  {activitySummary.meetingsHeld.slice(0, 5).map(m => (
+                    <div key={m.id} style={{ fontSize: 'var(--text-meta)', color: 'var(--text-2)', marginBottom: '2px' }}>
+                      · {m.title}
+                    </div>
+                  ))}
+                </div>
+                <div>
+                  <div className="form-label">Tasks completed</div>
+                  <div style={{ fontSize: 'var(--text-section)', fontWeight: 600, color: 'var(--text-1)', marginBottom: '8px' }}>
+                    {activitySummary.tasksCompleted.length}
+                  </div>
+                  {activitySummary.tasksCompleted.slice(0, 5).map(t => (
+                    <div key={t.id} style={{ fontSize: 'var(--text-meta)', color: 'var(--text-2)', marginBottom: '2px' }}>
+                      · {t.title}
+                    </div>
+                  ))}
+                </div>
+                <div>
+                  <div className="form-label">Evidence entries</div>
+                  <div style={{ fontSize: 'var(--text-section)', fontWeight: 600, color: 'var(--text-1)' }}>
+                    {activitySummary.evidenceLogged}
+                  </div>
+                </div>
+                <div>
+                  <div className="form-label">Action items created</div>
+                  <div style={{ fontSize: 'var(--text-section)', fontWeight: 600, color: 'var(--text-1)' }}>
+                    {activitySummary.actionItemsCreated}
+                  </div>
+                </div>
+              </div>
+            )
+          })()}
+
+          {/* Section 5: Reflection */}
+          <ReviewSection
+            title="Reflection"
+            signalCount={0}
+            isReviewed={sectionState.reflection}
+            onMarkReviewed={() => toggleSection('reflection')}
+            emptyMessage=""
+          >
+            {null}
+          </ReviewSection>
+
+          <div style={{
+            background: 'var(--surf)',
+            border: '1px solid var(--border-1)',
+            borderRadius: '8px',
+            padding: '16px',
+            marginTop: '-12px',
+          }}>
+            <textarea
+              value={notes}
+              onChange={e => handleNotesChange(e.target.value)}
+              placeholder="What went well this week? What needs attention next week? Any concerns about the team?"
+              rows={6}
+              disabled={isReadOnly}
+              style={{
+                width: '100%',
+                background: 'var(--surf-3)',
+                border: '1px solid var(--border-2)',
+                borderRadius: '4px',
+                color: 'var(--text-1)',
+                fontSize: 'var(--text-body)',
+                padding: '10px 12px',
+                resize: 'vertical',
+                fontFamily: 'var(--font-sans)',
+                outline: 'none',
+                boxSizing: 'border-box',
+                opacity: isReadOnly ? 0.7 : 1,
+              }}
+            />
+            {!isReadOnly && (
+              <p style={{ fontSize: 'var(--text-caption)', color: 'var(--text-3)', margin: '6px 0 0' }}>
+                Auto-saves as you type
+              </p>
+            )}
+          </div>
+
+          {/* Section 6: Complete Review */}
+          {isCurrentWeek && (
+            <div style={{
+              background: 'var(--surf)',
+              border: `1px solid ${isCompleted ? '#1a3a25' : 'var(--border-1)'}`,
+              borderRadius: '8px',
+              padding: '20px',
+            }}>
+              {/* Stats */}
+              <div style={{ display: 'flex', gap: '24px', marginBottom: '16px', flexWrap: 'wrap' }}>
+                <div style={{ fontSize: 'var(--text-meta)', color: 'var(--text-2)' }}>
+                  <span style={{ color: 'var(--text-1)', fontWeight: 600 }}>{dismissed.length}</span> dismissed
+                </div>
+                <div style={{ fontSize: 'var(--text-meta)', color: 'var(--text-2)' }}>
+                  <span style={{ color: signals.filter(s => s.severity === 'critical').length > 0 ? '#ff6b6b' : 'var(--text-1)', fontWeight: 600 }}>
+                    {signals.filter(s => s.severity === 'critical').length}
+                  </span> critical remaining
+                </div>
+                <div style={{ fontSize: 'var(--text-meta)', color: 'var(--text-2)' }}>
+                  <span style={{ color: 'var(--text-1)', fontWeight: 600 }}>{signals.length}</span> total remaining
+                </div>
+              </div>
+
+              {!isCompleted && signals.filter(s => s.severity === 'critical' || s.severity === 'warning').length > 0 && (
+                <p style={{ fontSize: 'var(--text-meta)', color: '#ffa94d', marginBottom: '12px' }}>
+                  You have {signals.filter(s => s.severity === 'critical' || s.severity === 'warning').length} unresolved items.
+                  You can still complete the review or address them first.
+                </p>
+              )}
+
+              {isCompleted ? (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                  <span style={{ fontSize: 'var(--text-body)', color: '#00f058', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '6px' }}>
+                    <CheckCircle style={{ width: '16px', height: '16px' }} />
+                    Week reviewed ✓
+                  </span>
+                  <button
+                    onClick={handleReopen}
+                    style={{
+                      background: 'none',
+                      border: '1px solid var(--border-2)',
+                      borderRadius: '4px',
+                      color: 'var(--text-3)',
+                      fontSize: 'var(--text-meta)',
+                      padding: '5px 12px',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    Reopen
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={handleComplete}
+                  disabled={completing}
+                  style={{
+                    background: 'linear-gradient(90deg, #00ffe5, #00f058)',
+                    border: 'none',
+                    borderRadius: '4px',
+                    color: '#000',
+                    fontSize: 'var(--text-body)',
+                    fontWeight: 600,
+                    padding: '10px 24px',
+                    cursor: completing ? 'not-allowed' : 'pointer',
+                    opacity: completing ? 0.7 : 1,
+                  }}
+                >
+                  {completing ? 'Saving...' : 'Mark Week as Reviewed'}
+                </button>
+              )}
+            </div>
+          )}
+
+        </div>
+      )}
+
+      {/* Dismiss dialog */}
+      {dismissTarget && (
+        <DismissDialog
+          onConfirm={(note) => handleDismiss(dismissTarget, note)}
+          onCancel={() => setDismissTarget(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -49,7 +49,7 @@
     --text-page-title:   24px;   /* h1: page headings */
     --text-section:      14px;   /* h2: widget/section titles */
     --text-body:         14px;   /* default body text */
-    --text-label:        12px;   /* secondary labels, captions */
+    --text-label:        14px;   /* secondary labels, captions */
     --text-meta:         12px;   /* table cells, metadata */
     --text-caption:      10px;   /* tags, badges, tiny labels */
     --text-overline:     11px;   /* uppercase column/stat headers */

--- a/app/globals.css
+++ b/app/globals.css
@@ -187,3 +187,35 @@ h2 { font-size: var(--text-section);    font-weight: var(--weight-section); colo
 h3 { font-size: var(--text-section);    font-weight: var(--weight-section); color: var(--text-1); }
 p  { font-size: var(--text-body);       color: var(--text-2); }
 label { font-size: var(--text-label); color: var(--text-2); }
+
+/* ── Sidebar nav items ── */
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 7px;
+  border-radius: 4px;
+  margin-bottom: 1px;
+  font-size: var(--text-meta);
+  font-family: var(--font-sans);
+  color: var(--text-2);
+  background: transparent;
+  border-right: 2px solid transparent;
+  text-decoration: none;
+  justify-content: flex-start;
+  font-weight: 500;
+}
+
+.nav-item:hover {
+  background: var(--surf-2);
+}
+
+.nav-item.active {
+  color: var(--text-1);
+  background: var(--surf-3);
+  border-right-color: #00f058;
+}
+
+.nav-item-collapsed {
+  justify-content: center;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,7 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "Cadence - Engineering Manager Control Centre",
+  title: "Cadence - EM Control Centre",
   description: "A lightweight web platform for engineering managers to run their day-to-day work effectively",
   icons: {
     icon: [

--- a/components/__tests__/follow-up-list.test.tsx
+++ b/components/__tests__/follow-up-list.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '../../test/mocks/supabase'
+import { FollowUpList } from '../follow-ups/follow-up-list'
+import type { FollowUp } from '@/lib/services/follow-ups'
+
+const mockCompleteFollowUp = vi.fn().mockResolvedValue({})
+const mockCancelFollowUp = vi.fn().mockResolvedValue({})
+
+vi.mock('@/lib/services/follow-ups', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/services/follow-ups')>()
+  return {
+    ...actual,
+    completeFollowUp: (...args: unknown[]) => mockCompleteFollowUp(...args),
+    cancelFollowUp: (...args: unknown[]) => mockCancelFollowUp(...args),
+    deleteFollowUp: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+function makeFollowUp(overrides: Partial<FollowUp> = {}): FollowUp {
+  return {
+    id: 'fu-1',
+    userId: 'user-1',
+    personId: 'person-1',
+    personName: 'Alice Smith',
+    title: 'Check in on project blockers',
+    description: null,
+    sourceType: null,
+    sourceId: null,
+    sourceName: null,
+    status: 'open',
+    dueDate: null,
+    createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+    completedAt: null,
+    cancelledAt: null,
+    lastSurfacedAt: null,
+    timesSurfaced: 0,
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('FollowUpList', () => {
+  it('renders empty state when no follow-ups', () => {
+    render(<FollowUpList followUps={[]} onChanged={vi.fn()} />)
+    expect(screen.getByText('No follow-ups')).toBeInTheDocument()
+  })
+
+  it('renders open follow-up title', () => {
+    render(<FollowUpList followUps={[makeFollowUp()]} onChanged={vi.fn()} />)
+    expect(screen.getByText('Check in on project blockers')).toBeInTheDocument()
+  })
+
+  it('shows Open badge for open follow-up without due date', () => {
+    render(<FollowUpList followUps={[makeFollowUp()]} onChanged={vi.fn()} />)
+    expect(screen.getByText('Open')).toBeInTheDocument()
+  })
+
+  it('shows Overdue badge when past due date', () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+      .toISOString().split('T')[0]
+    render(<FollowUpList followUps={[makeFollowUp({ dueDate: yesterday })]} onChanged={vi.fn()} />)
+    expect(screen.getByText('Overdue')).toBeInTheDocument()
+  })
+
+  it('does not show Overdue badge for future due date', () => {
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000)
+      .toISOString().split('T')[0]
+    render(<FollowUpList followUps={[makeFollowUp({ dueDate: tomorrow })]} onChanged={vi.fn()} />)
+    expect(screen.queryByText('Overdue')).not.toBeInTheDocument()
+  })
+
+  it('calls completeFollowUp and onChanged when Done clicked', async () => {
+    const onChanged = vi.fn()
+    render(<FollowUpList followUps={[makeFollowUp()]} onChanged={onChanged} />)
+
+    fireEvent.click(screen.getByTitle('Mark complete'))
+
+    await waitFor(() => {
+      expect(mockCompleteFollowUp).toHaveBeenCalledWith('fu-1')
+      expect(onChanged).toHaveBeenCalled()
+    })
+  })
+
+  it('calls cancelFollowUp and onChanged when cancel clicked', async () => {
+    const onChanged = vi.fn()
+    render(<FollowUpList followUps={[makeFollowUp()]} onChanged={onChanged} />)
+
+    fireEvent.click(screen.getByTitle('Cancel'))
+
+    await waitFor(() => {
+      expect(mockCancelFollowUp).toHaveBeenCalledWith('fu-1')
+      expect(onChanged).toHaveBeenCalled()
+    })
+  })
+
+  it('shows closed count button and expands on click', () => {
+    const closed = makeFollowUp({ id: 'fu-2', status: 'completed', completedAt: '2026-05-01T10:00:00Z', title: 'Old task done' })
+    render(<FollowUpList followUps={[makeFollowUp(), closed]} onChanged={vi.fn()} />)
+
+    expect(screen.getByText('1 closed')).toBeInTheDocument()
+    expect(screen.queryByText('Old task done')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('1 closed'))
+    expect(screen.getByText('Old task done')).toBeInTheDocument()
+  })
+
+  it('shows Done badge for completed follow-up when expanded', () => {
+    const closed = makeFollowUp({ id: 'fu-2', status: 'completed', completedAt: '2026-05-01T10:00:00Z', title: 'Finished item' })
+    render(<FollowUpList followUps={[closed]} onChanged={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('1 closed'))
+    expect(screen.getByText('Done')).toBeInTheDocument()
+  })
+
+  it('shows person name link when showPerson=true', () => {
+    render(<FollowUpList followUps={[makeFollowUp()]} onChanged={vi.fn()} showPerson={true} />)
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+  })
+
+  it('does not show person name when showPerson=false (default)', () => {
+    render(<FollowUpList followUps={[makeFollowUp()]} onChanged={vi.fn()} />)
+    expect(screen.queryByText('Alice Smith')).not.toBeInTheDocument()
+  })
+
+  it('shows source name when present', () => {
+    const fu = makeFollowUp({ sourceName: 'Sprint Retro', sourceType: 'meeting' })
+    render(<FollowUpList followUps={[fu]} onChanged={vi.fn()} />)
+    expect(screen.getByText(/Sprint Retro/)).toBeInTheDocument()
+  })
+
+  it('shows due date when set', () => {
+    const fu = makeFollowUp({ dueDate: '2026-05-15' })
+    render(<FollowUpList followUps={[fu]} onChanged={vi.fn()} />)
+    expect(screen.getByText(/Due/)).toBeInTheDocument()
+  })
+
+  it('shows age in days when no due date', () => {
+    render(<FollowUpList followUps={[makeFollowUp()]} onChanged={vi.fn()} />)
+    expect(screen.getByText(/\dd old/)).toBeInTheDocument()
+  })
+})

--- a/components/__tests__/review-section.test.tsx
+++ b/components/__tests__/review-section.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ReviewSection } from '../review/review-section'
+
+describe('ReviewSection', () => {
+  const defaultProps = {
+    title: 'People Check',
+    signalCount: 0,
+    isReviewed: false,
+    onMarkReviewed: vi.fn(),
+    children: null,
+  }
+
+  it('renders title', () => {
+    render(<ReviewSection {...defaultProps} />)
+    expect(screen.getByText('People Check')).toBeTruthy()
+  })
+
+  it('shows empty message when signalCount is 0', () => {
+    render(<ReviewSection {...defaultProps} emptyMessage="All clear ✓" />)
+    expect(screen.getByText('All clear ✓')).toBeTruthy()
+  })
+
+  it('shows Reviewed badge when isReviewed is true', () => {
+    render(<ReviewSection {...defaultProps} isReviewed={true} />)
+    expect(screen.getByText('Reviewed')).toBeTruthy()
+  })
+
+  it('does not show Reviewed badge when not reviewed', () => {
+    render(<ReviewSection {...defaultProps} isReviewed={false} />)
+    expect(screen.queryByText('Reviewed')).toBeNull()
+  })
+
+  it('shows critical badge when criticalCount > 0', () => {
+    render(<ReviewSection {...defaultProps} signalCount={2} criticalCount={1} warningCount={1} />)
+    expect(screen.getByText('1 critical')).toBeTruthy()
+    expect(screen.getByText('1 warning')).toBeTruthy()
+  })
+
+  it('hides signal badges when isReviewed is true', () => {
+    render(<ReviewSection {...defaultProps} signalCount={2} criticalCount={2} isReviewed={true} />)
+    expect(screen.queryByText('2 critical')).toBeNull()
+  })
+
+  it('calls onMarkReviewed when checkbox clicked', () => {
+    const onMarkReviewed = vi.fn()
+    render(<ReviewSection {...defaultProps} onMarkReviewed={onMarkReviewed} />)
+    const checkbox = screen.getByTitle('Mark as reviewed')
+    fireEvent.click(checkbox)
+    expect(onMarkReviewed).toHaveBeenCalledWith(true)
+  })
+
+  it('collapses body when header is clicked', () => {
+    render(<ReviewSection {...defaultProps} emptyMessage="All clear ✓" />)
+    expect(screen.getByText('All clear ✓')).toBeTruthy()
+    fireEvent.click(screen.getByText('People Check'))
+    expect(screen.queryByText('All clear ✓')).toBeNull()
+  })
+
+  it('renders children when signalCount > 0', () => {
+    render(
+      <ReviewSection {...defaultProps} signalCount={1}>
+        <div>Signal content</div>
+      </ReviewSection>
+    )
+    expect(screen.getByText('Signal content')).toBeTruthy()
+  })
+})

--- a/components/dashboard/weekly-review-banner.tsx
+++ b/components/dashboard/weekly-review-banner.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { ArrowRight, CheckCircle } from 'lucide-react'
+import { getMondayOfWeek, getWeeklyReview, type WeeklyReview } from '@/lib/services/weekly-review'
+import { fetchSignalCounts } from '@/lib/hooks/use-weekly-review-signals'
+
+export function WeeklyReviewBanner() {
+  const [review, setReview] = useState<WeeklyReview | null | undefined>(undefined)
+  const [signalCount, setSignalCount] = useState(0)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const weekStart = getMondayOfWeek()
+        const r = await getWeeklyReview(weekStart)
+        setReview(r)
+        if (!r || r.status === 'in_progress') {
+          const counts = await fetchSignalCounts()
+          setSignalCount(counts.total)
+        }
+      } catch {
+        // non-critical
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  if (loading || review === undefined) return null
+
+  // Completed — show subtle badge
+  if (review?.status === 'completed') {
+    return (
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        padding: '10px 14px',
+        background: '#0d1f14',
+        border: '1px solid #1a3a25',
+        borderRadius: '8px',
+        fontSize: 'var(--text-meta)',
+        color: '#00c44a',
+      }}>
+        <CheckCircle style={{ width: '13px', height: '13px' }} />
+        Week reviewed ✓
+      </div>
+    )
+  }
+
+  const today = new Date()
+  const dayOfWeek = today.getDay() // 0=Sun, 1=Mon
+  const isEarlyWeek = dayOfWeek === 0 || dayOfWeek === 1 || dayOfWeek === 2
+
+  // In-progress review
+  if (review?.status === 'in_progress') {
+    return (
+      <Link href="/review" style={{ textDecoration: 'none' }}>
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '10px',
+          padding: '12px 16px',
+          background: '#1a1a2e',
+          border: '1px solid #2a2a4a',
+          borderRadius: '8px',
+          cursor: 'pointer',
+          transition: 'border-color 0.15s',
+        }}>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 'var(--text-body)', fontWeight: 600, color: 'var(--text-1)', marginBottom: '2px' }}>
+              Continue your weekly review
+            </div>
+            <div style={{ fontSize: 'var(--text-meta)', color: 'var(--text-2)' }}>
+              {signalCount > 0 ? `${signalCount} item${signalCount === 1 ? '' : 's'} remaining` : 'Pick up where you left off'}
+            </div>
+          </div>
+          <ArrowRight style={{ width: '14px', height: '14px', color: 'var(--text-3)' }} />
+        </div>
+      </Link>
+    )
+  }
+
+  // No review yet — prompt on Mon/Tue/Wed
+  if (!review && isEarlyWeek) {
+    return (
+      <Link href="/review" style={{ textDecoration: 'none' }}>
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '10px',
+          padding: '12px 16px',
+          background: 'linear-gradient(135deg, #0f1f15 0%, #1a1a2e 100%)',
+          border: '1px solid #2a3a30',
+          borderRadius: '8px',
+          cursor: 'pointer',
+        }}>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 'var(--text-body)', fontWeight: 600, color: 'var(--text-1)', marginBottom: '2px' }}>
+              Start your weekly review
+            </div>
+            <div style={{ fontSize: 'var(--text-meta)', color: 'var(--text-2)' }}>
+              {signalCount > 0 ? `${signalCount} signal${signalCount === 1 ? '' : 's'} to check` : 'Review your week and close the loop'}
+            </div>
+          </div>
+          <ArrowRight style={{ width: '14px', height: '14px', color: 'var(--text-3)' }} />
+        </div>
+      </Link>
+    )
+  }
+
+  return null
+}

--- a/components/evidence/__tests__/evidence-section.test.tsx
+++ b/components/evidence/__tests__/evidence-section.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { EvidenceSection } from '../evidence-section'
+import type { EvidenceEntry } from '@/lib/services/evidence'
+
+// Mock the evidence service
+vi.mock('@/lib/services/evidence', () => ({
+  getEvidenceForPerson: vi.fn(),
+  createEvidence: vi.fn(),
+  updateEvidence: vi.fn(),
+  deleteEvidence: vi.fn(),
+}))
+
+import {
+  getEvidenceForPerson,
+  createEvidence,
+  deleteEvidence,
+} from '@/lib/services/evidence'
+
+const mockEntry: EvidenceEntry = {
+  id: 'ev-1',
+  personId: 'person-1',
+  personName: 'Alice Smith',
+  category: 'achievement',
+  title: 'Shipped new feature',
+  content: 'Delivered ahead of schedule',
+  occurredAt: '2026-03-15',
+  meetingId: null,
+  meetingTitle: null,
+  taskId: null,
+  taskTitle: null,
+  sentiment: 'positive',
+  reviewPeriodStart: null,
+  reviewPeriodEnd: null,
+  includedInReview: true,
+  createdAt: '2026-03-15T10:00:00Z',
+  updatedAt: '2026-03-15T10:00:00Z',
+}
+
+describe('EvidenceSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getEvidenceForPerson).mockResolvedValue([])
+    vi.mocked(createEvidence).mockResolvedValue(mockEntry)
+    vi.mocked(deleteEvidence).mockResolvedValue(undefined)
+  })
+
+  it('should render the section header with person name', async () => {
+    render(<EvidenceSection personId="person-1" personName="Alice Smith" />)
+    expect(screen.getByRole('heading', { name: /Evidence/ })).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText(/Alice Smith/)).toBeInTheDocument()
+    })
+  })
+
+  it('should show empty state when no entries', async () => {
+    render(<EvidenceSection personId="person-1" personName="Alice Smith" />)
+    await waitFor(() => {
+      expect(screen.getByText(/No evidence logged yet/)).toBeInTheDocument()
+    })
+  })
+
+  it('should render evidence entries after load', async () => {
+    vi.mocked(getEvidenceForPerson).mockResolvedValue([mockEntry])
+    render(<EvidenceSection personId="person-1" personName="Alice Smith" />)
+    await waitFor(() => {
+      expect(screen.getByText('Shipped new feature')).toBeInTheDocument()
+    })
+  })
+
+  it('should render category badge with correct label', async () => {
+    vi.mocked(getEvidenceForPerson).mockResolvedValue([mockEntry])
+    render(<EvidenceSection personId="person-1" personName="Alice Smith" />)
+    await waitFor(() => {
+      expect(screen.getByText('Achievement')).toBeInTheDocument()
+    })
+  })
+
+  it('should render sentiment indicator', async () => {
+    vi.mocked(getEvidenceForPerson).mockResolvedValue([mockEntry])
+    render(<EvidenceSection personId="person-1" personName="Alice Smith" />)
+    await waitFor(() => {
+      expect(screen.getByText(/Positive/)).toBeInTheDocument()
+    })
+  })
+
+  it('should show add evidence form when button clicked', async () => {
+    render(<EvidenceSection personId="person-1" personName="Alice Smith" />)
+    const user = userEvent.setup()
+    const addButton = screen.getByRole('button', { name: /Add Evidence/i })
+    await user.click(addButton)
+    expect(screen.getByPlaceholderText(/Brief description of the evidence/)).toBeInTheDocument()
+  })
+
+  it('should show sentiment toggle buttons in form', async () => {
+    render(<EvidenceSection personId="person-1" personName="Alice Smith" />)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /Add Evidence/i }))
+    expect(screen.getByRole('button', { name: /Positive/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Neutral/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Negative/i })).toBeInTheDocument()
+  })
+
+  it('should disable Save button when title is empty', async () => {
+    render(<EvidenceSection personId="person-1" personName="Alice Smith" />)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /Add Evidence/i }))
+    const saveButton = screen.getByRole('button', { name: /Save Evidence/i })
+    expect(saveButton).toBeDisabled()
+  })
+
+  it('should call createEvidence on form submit', async () => {
+    render(<EvidenceSection personId="person-1" personName="Alice Smith" />)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /Add Evidence/i }))
+    await user.type(screen.getByPlaceholderText(/Brief description of the evidence/), 'Great delivery')
+    await user.click(screen.getByRole('button', { name: /Save Evidence/i }))
+    await waitFor(() => {
+      expect(createEvidence).toHaveBeenCalledWith(
+        expect.objectContaining({
+          personId: 'person-1',
+          title: 'Great delivery',
+        })
+      )
+    })
+  })
+
+  it('should hide form after successful save', async () => {
+    render(<EvidenceSection personId="person-1" personName="Alice Smith" />)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /Add Evidence/i }))
+    await user.type(screen.getByPlaceholderText(/Brief description of the evidence/), 'Test entry')
+    await user.click(screen.getByRole('button', { name: /Save Evidence/i }))
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText(/Brief description of the evidence/)).not.toBeInTheDocument()
+    })
+  })
+
+  it('should expand entry on click to show content', async () => {
+    vi.mocked(getEvidenceForPerson).mockResolvedValue([mockEntry])
+    render(<EvidenceSection personId="person-1" personName="Alice Smith" />)
+    const user = userEvent.setup()
+    await waitFor(() => screen.getByText('Shipped new feature'))
+    await user.click(screen.getByText('Shipped new feature').closest('div[style]')!)
+    await waitFor(() => {
+      expect(screen.getByText('Delivered ahead of schedule')).toBeInTheDocument()
+    })
+  })
+
+  it('should call deleteEvidence when delete button clicked', async () => {
+    vi.mocked(getEvidenceForPerson).mockResolvedValue([mockEntry])
+    render(<EvidenceSection personId="person-1" personName="Alice Smith" />)
+    const user = userEvent.setup()
+    await waitFor(() => screen.getByText('Shipped new feature'))
+    // Expand the entry first
+    await user.click(screen.getByText('Shipped new feature').closest('div[style]')!)
+    await waitFor(() => screen.getByRole('button', { name: /Delete/i }))
+    await user.click(screen.getByRole('button', { name: /Delete/i }))
+    await waitFor(() => {
+      expect(deleteEvidence).toHaveBeenCalledWith('ev-1')
+    })
+  })
+
+  it('should show Review Prep link', async () => {
+    render(<EvidenceSection personId="person-1" personName="Alice Smith" />)
+    expect(screen.getByRole('link', { name: /Review Prep/i })).toHaveAttribute('href', '/people/person-1/review')
+  })
+
+  it('should show linked meeting indicator when meetingId set', async () => {
+    const entryWithMeeting: EvidenceEntry = {
+      ...mockEntry,
+      meetingId: 'meeting-1',
+      meetingTitle: '1:1 with Alice',
+    }
+    vi.mocked(getEvidenceForPerson).mockResolvedValue([entryWithMeeting])
+    render(<EvidenceSection personId="person-1" personName="Alice Smith" />)
+    await waitFor(() => {
+      // Link2 icon rendered on the row
+      const row = screen.getByText('Shipped new feature').closest('div[style]')!
+      expect(row).toBeInTheDocument()
+    })
+  })
+})

--- a/components/evidence/evidence-section.tsx
+++ b/components/evidence/evidence-section.tsx
@@ -1,0 +1,446 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Plus, ChevronDown, ChevronRight, Link2, Trash2, Check } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { MarkdownTextarea } from "@/components/ui/markdown-textarea"
+import {
+  getEvidenceForPerson,
+  createEvidence,
+  updateEvidence,
+  deleteEvidence,
+  type EvidenceEntry,
+  type EvidenceCategory,
+  type EvidenceSentiment,
+} from "@/lib/services/evidence"
+
+const CATEGORY_LABELS: Record<EvidenceCategory, string> = {
+  achievement: "Achievement",
+  feedback_given: "Feedback Given",
+  feedback_received: "Feedback Received",
+  concern: "Concern",
+  growth: "Growth",
+  delivery: "Delivery",
+  behaviour: "Behaviour",
+  promotion_evidence: "Promotion Evidence",
+  general: "General",
+}
+
+const CATEGORY_COLORS: Record<EvidenceCategory, { bg: string; color: string }> = {
+  achievement:        { bg: "#0d2015", color: "#4ade80" },
+  feedback_given:     { bg: "#0c1a3d", color: "#60a5fa" },
+  feedback_received:  { bg: "#1a0d2e", color: "#c084fc" },
+  concern:            { bg: "#2a0a0a", color: "#f87171" },
+  growth:             { bg: "#0d1e1e", color: "#2dd4bf" },
+  delivery:           { bg: "#0f1526", color: "#818cf8" },
+  behaviour:          { bg: "#1e1500", color: "#fbbf24" },
+  promotion_evidence: { bg: "#1e1200", color: "#f59e0b" },
+  general:            { bg: "#1a1a1a", color: "#9ca3af" },
+}
+
+const SENTIMENT_CONFIG = {
+  positive: { label: "Positive", color: "#4ade80", symbol: "↑" },
+  neutral:  { label: "Neutral",  color: "#9ca3af", symbol: "–" },
+  negative: { label: "Negative", color: "#f87171", symbol: "↓" },
+}
+
+const CATEGORIES = Object.keys(CATEGORY_LABELS) as EvidenceCategory[]
+const SENTIMENTS: EvidenceSentiment[] = ["positive", "neutral", "negative"]
+
+interface EvidenceFormState {
+  category: EvidenceCategory
+  title: string
+  content: string
+  occurredAt: string
+  sentiment: EvidenceSentiment
+}
+
+const emptyForm = (): EvidenceFormState => ({
+  category: "general",
+  title: "",
+  content: "",
+  occurredAt: new Date().toISOString().split("T")[0],
+  sentiment: "neutral",
+})
+
+interface EvidenceSectionProps {
+  personId: string
+  personName: string
+  /** Pre-linked meeting for "Log as Evidence" flow */
+  prefillMeetingId?: string
+  prefillMeetingTitle?: string
+  prefillMeetingDate?: string
+  onPrefillConsumed?: () => void
+}
+
+export function EvidenceSection({
+  personId,
+  personName,
+  prefillMeetingId,
+  prefillMeetingTitle,
+  prefillMeetingDate,
+  onPrefillConsumed,
+}: EvidenceSectionProps) {
+  const [entries, setEntries] = useState<EvidenceEntry[]>([])
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState<EvidenceFormState>(emptyForm())
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editForm, setEditForm] = useState<EvidenceFormState>(emptyForm())
+  const [saving, setSaving] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [linkedMeetingId, setLinkedMeetingId] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    getEvidenceForPerson(personId).then(setEntries).catch(console.error)
+  }, [personId])
+
+  // Handle prefill from "Log as Evidence" button on meeting detail
+  useEffect(() => {
+    if (prefillMeetingId) {
+      setForm({
+        ...emptyForm(),
+        title: prefillMeetingTitle ? `From meeting: ${prefillMeetingTitle}` : "",
+        occurredAt: prefillMeetingDate ?? new Date().toISOString().split("T")[0],
+        category: "general",
+      })
+      setLinkedMeetingId(prefillMeetingId)
+      setShowForm(true)
+      onPrefillConsumed?.()
+    }
+  }, [prefillMeetingId, prefillMeetingTitle, prefillMeetingDate, onPrefillConsumed])
+
+  const handleSubmit = async () => {
+    if (!form.title.trim()) return
+    setSaving(true)
+    try {
+      const created = await createEvidence({
+        personId,
+        category: form.category,
+        title: form.title.trim(),
+        content: form.content.trim() || null,
+        occurredAt: form.occurredAt,
+        sentiment: form.sentiment,
+        meetingId: linkedMeetingId ?? null,
+        taskId: null,
+        includedInReview: true,
+        reviewPeriodStart: null,
+        reviewPeriodEnd: null,
+      })
+      setEntries([created, ...entries])
+      setForm(emptyForm())
+      setLinkedMeetingId(undefined)
+      setShowForm(false)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleStartEdit = (entry: EvidenceEntry) => {
+    setEditingId(entry.id)
+    setEditForm({
+      category: entry.category,
+      title: entry.title,
+      content: entry.content ?? "",
+      occurredAt: entry.occurredAt,
+      sentiment: entry.sentiment ?? "neutral",
+    })
+  }
+
+  const handleSaveEdit = async (id: string) => {
+    setSaving(true)
+    try {
+      const updated = await updateEvidence(id, {
+        category: editForm.category,
+        title: editForm.title.trim(),
+        content: editForm.content.trim() || null,
+        occurredAt: editForm.occurredAt,
+        sentiment: editForm.sentiment,
+      })
+      setEntries(entries.map(e => e.id === id ? updated : e))
+      setEditingId(null)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    setDeletingId(id)
+    try {
+      await deleteEvidence(id)
+      setEntries(entries.filter(e => e.id !== id))
+      if (expandedId === id) setExpandedId(null)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  const formatDate = (d: string) =>
+    new Date(d).toLocaleDateString("en-GB", { day: "2-digit", month: "short", year: "numeric" })
+
+  return (
+    <div style={{ background: "var(--surf)", border: "1px solid var(--border-1)", borderRadius: "8px", overflow: "hidden" }}>
+      {/* Header */}
+      <div style={{ padding: "16px 20px", borderBottom: "1px solid var(--border-1)", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <div>
+          <h2>Evidence</h2>
+          <p style={{ marginTop: "2px" }}>
+            {entries.length} {entries.length === 1 ? "entry" : "entries"} logged for {personName}
+          </p>
+        </div>
+        <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+          <a
+            href={`/people/${personId}/review`}
+            style={{ display: "inline-flex", alignItems: "center", gap: "4px", padding: "4px 10px", borderRadius: "4px", fontSize: "var(--text-caption)", fontWeight: 600, color: "var(--text-2)", border: "1px solid var(--border-2)", background: "var(--surf-2)", textDecoration: "none", cursor: "pointer" }}
+          >
+            Review Prep
+          </a>
+          <button
+            onClick={() => { setShowForm(true); setLinkedMeetingId(undefined) }}
+            style={{ display: "inline-flex", alignItems: "center", gap: "4px", background: "linear-gradient(90deg, #00ffe5 0%, #00f058 100%)", border: "none", color: "#0a1a0a", padding: "4px 10px", borderRadius: "4px", fontSize: "var(--text-caption)", fontWeight: 600, cursor: "pointer", fontFamily: "var(--font-sans)" }}
+          >
+            <Plus style={{ width: "11px", height: "11px" }} /> Add Evidence
+          </button>
+        </div>
+      </div>
+
+      {/* Quick-add form */}
+      {showForm && (
+        <div style={{ padding: "20px 24px", borderBottom: "1px solid var(--border-1)", background: "var(--surf-2)" }}>
+          <div style={{ display: "grid", gap: "14px" }}>
+            {/* Row 1: category + date */}
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 180px", gap: "12px" }}>
+              <div style={{ display: "grid", gap: "4px" }}>
+                <label className="form-label">Category</label>
+                <select
+                  value={form.category}
+                  onChange={e => setForm({ ...form, category: e.target.value as EvidenceCategory })}
+                  style={{ background: "var(--surf)", border: "1px solid var(--border-2)", borderRadius: "6px", color: "var(--text-1)", padding: "6px 10px", fontSize: "var(--text-label)", cursor: "pointer" }}
+                >
+                  {CATEGORIES.map(c => (
+                    <option key={c} value={c}>{CATEGORY_LABELS[c]}</option>
+                  ))}
+                </select>
+              </div>
+              <div style={{ display: "grid", gap: "4px" }}>
+                <label className="form-label">Date</label>
+                <Input type="date" value={form.occurredAt} onChange={e => setForm({ ...form, occurredAt: e.target.value })} />
+              </div>
+            </div>
+
+            {/* Row 2: title */}
+            <div style={{ display: "grid", gap: "4px" }}>
+              <label className="form-label">Title *</label>
+              <Input
+                value={form.title}
+                onChange={e => setForm({ ...form, title: e.target.value })}
+                placeholder="Brief description of the evidence..."
+                onKeyDown={e => { if (e.key === "Enter" && !e.shiftKey) handleSubmit() }}
+              />
+            </div>
+
+            {/* Row 3: content */}
+            <div style={{ display: "grid", gap: "4px" }}>
+              <label className="form-label">Notes (optional)</label>
+              <MarkdownTextarea
+                value={form.content}
+                onValueChange={v => setForm({ ...form, content: v })}
+                placeholder="Add context, specifics, or quotes..."
+                rows={3}
+              />
+            </div>
+
+            {/* Row 4: sentiment + linked meeting notice + actions */}
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                <label className="form-label" style={{ margin: 0 }}>Sentiment</label>
+                <div style={{ display: "flex", gap: "4px" }}>
+                  {SENTIMENTS.map(s => {
+                    const cfg = SENTIMENT_CONFIG[s]
+                    const active = form.sentiment === s
+                    return (
+                      <button
+                        key={s}
+                        type="button"
+                        onClick={() => setForm({ ...form, sentiment: s })}
+                        style={{
+                          padding: "3px 10px", borderRadius: "4px", fontSize: "var(--text-label)", fontWeight: 500,
+                          cursor: "pointer", border: `1px solid ${active ? cfg.color + "60" : "var(--border-2)"}`,
+                          background: active ? cfg.color + "15" : "var(--surf-2)", color: active ? cfg.color : "var(--text-3)",
+                        }}
+                      >{cfg.symbol} {cfg.label}</button>
+                    )
+                  })}
+                </div>
+                {linkedMeetingId && (
+                  <span style={{ display: "inline-flex", alignItems: "center", gap: "4px", fontSize: "var(--text-caption)", color: "#60a5fa" }}>
+                    <Link2 style={{ width: "11px", height: "11px" }} /> Linked to meeting
+                  </span>
+                )}
+              </div>
+              <div style={{ display: "flex", gap: "8px" }}>
+                <Button variant="outline" onClick={() => { setShowForm(false); setForm(emptyForm()); setLinkedMeetingId(undefined) }}>Cancel</Button>
+                <Button onClick={handleSubmit} disabled={!form.title.trim() || saving}>
+                  {saving ? "Saving..." : "Save Evidence"}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Timeline */}
+      <div style={{ padding: "12px 0", minHeight: "120px" }}>
+        {entries.length === 0 && !showForm ? (
+          <div style={{ padding: "40px 24px", textAlign: "center" }}>
+            <p style={{ color: "var(--text-3)", marginBottom: "12px" }}>
+              No evidence logged yet. Start capturing achievements, feedback, and observations throughout the year.
+            </p>
+            <Button onClick={() => setShowForm(true)}>
+              <Plus style={{ width: "14px", height: "14px" }} /> Add First Entry
+            </Button>
+          </div>
+        ) : (
+          entries.map(entry => {
+            const cat = CATEGORY_COLORS[entry.category]
+            const sent = entry.sentiment ? SENTIMENT_CONFIG[entry.sentiment] : null
+            const isExpanded = expandedId === entry.id
+            const isEditing = editingId === entry.id
+
+            return (
+              <div key={entry.id} style={{ borderBottom: "1px solid var(--border-1)", transition: "background 0.1s" }}>
+                {/* Entry row */}
+                <div
+                  style={{ padding: "10px 20px", display: "flex", alignItems: "center", gap: "10px", cursor: "pointer" }}
+                  onClick={() => setExpandedId(isExpanded ? null : entry.id)}
+                  onMouseEnter={e => (e.currentTarget.style.background = "#292929")}
+                  onMouseLeave={e => (e.currentTarget.style.background = "transparent")}
+                >
+                  {isExpanded
+                    ? <ChevronDown style={{ width: "12px", height: "12px", color: "var(--text-3)", flexShrink: 0 }} />
+                    : <ChevronRight style={{ width: "12px", height: "12px", color: "var(--text-3)", flexShrink: 0 }} />}
+
+                  {/* Category badge */}
+                  <span style={{ padding: "2px 7px", borderRadius: "3px", fontSize: "var(--text-caption)", fontWeight: 600, background: cat.bg, color: cat.color, flexShrink: 0 }}>
+                    {CATEGORY_LABELS[entry.category]}
+                  </span>
+
+                  {/* Title */}
+                  <span style={{ flex: 1, fontSize: "var(--text-label)", color: "var(--text-1)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {entry.title}
+                  </span>
+
+                  {/* Sentiment */}
+                  {sent && (
+                    <span style={{ fontSize: "var(--text-caption)", color: sent.color, flexShrink: 0 }}>
+                      {sent.symbol} {sent.label}
+                    </span>
+                  )}
+
+                  {/* Date */}
+                  <span style={{ fontSize: "var(--text-caption)", color: "var(--text-3)", flexShrink: 0, minWidth: "90px", textAlign: "right" }}>
+                    {formatDate(entry.occurredAt)}
+                  </span>
+
+                  {/* Meeting link indicator */}
+                  {entry.meetingId && (
+                    <span title={`Linked to meeting: ${entry.meetingTitle ?? entry.meetingId}`} style={{ color: "#60a5fa" }}>
+                      <Link2 style={{ width: "12px", height: "12px" }} />
+                    </span>
+                  )}
+                </div>
+
+                {/* Expanded content */}
+                {isExpanded && (
+                  <div style={{ padding: "12px 20px 16px 42px", borderTop: "1px solid var(--border-1)", background: "var(--surf-2)" }}>
+                    {isEditing ? (
+                      <div style={{ display: "grid", gap: "12px" }}>
+                        <div style={{ display: "grid", gridTemplateColumns: "1fr 180px", gap: "12px" }}>
+                          <div style={{ display: "grid", gap: "4px" }}>
+                            <label className="form-label">Category</label>
+                            <select
+                              value={editForm.category}
+                              onChange={e => setEditForm({ ...editForm, category: e.target.value as EvidenceCategory })}
+                              style={{ background: "var(--surf)", border: "1px solid var(--border-2)", borderRadius: "6px", color: "var(--text-1)", padding: "6px 10px", fontSize: "var(--text-label)", cursor: "pointer" }}
+                            >
+                              {CATEGORIES.map(c => <option key={c} value={c}>{CATEGORY_LABELS[c]}</option>)}
+                            </select>
+                          </div>
+                          <div style={{ display: "grid", gap: "4px" }}>
+                            <label className="form-label">Date</label>
+                            <Input type="date" value={editForm.occurredAt} onChange={e => setEditForm({ ...editForm, occurredAt: e.target.value })} />
+                          </div>
+                        </div>
+                        <div style={{ display: "grid", gap: "4px" }}>
+                          <label className="form-label">Title</label>
+                          <Input value={editForm.title} onChange={e => setEditForm({ ...editForm, title: e.target.value })} />
+                        </div>
+                        <div style={{ display: "grid", gap: "4px" }}>
+                          <label className="form-label">Notes</label>
+                          <MarkdownTextarea value={editForm.content} onValueChange={v => setEditForm({ ...editForm, content: v })} rows={3} />
+                        </div>
+                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px" }}>
+                          <div style={{ display: "flex", gap: "4px" }}>
+                            {SENTIMENTS.map(s => {
+                              const cfg = SENTIMENT_CONFIG[s]
+                              const active = editForm.sentiment === s
+                              return (
+                                <button key={s} type="button" onClick={() => setEditForm({ ...editForm, sentiment: s })}
+                                  style={{ padding: "3px 10px", borderRadius: "4px", fontSize: "var(--text-label)", fontWeight: 500, cursor: "pointer", border: `1px solid ${active ? cfg.color + "60" : "var(--border-2)"}`, background: active ? cfg.color + "15" : "var(--surf-2)", color: active ? cfg.color : "var(--text-3)" }}>
+                                  {cfg.symbol} {cfg.label}
+                                </button>
+                              )
+                            })}
+                          </div>
+                          <div style={{ display: "flex", gap: "8px" }}>
+                            <Button variant="outline" onClick={() => setEditingId(null)}>Cancel</Button>
+                            <Button onClick={() => handleSaveEdit(entry.id)} disabled={saving}>
+                              <Check style={{ width: "13px", height: "13px" }} /> Save
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                    ) : (
+                      <div>
+                        {entry.content ? (
+                          <p style={{ fontSize: "var(--text-label)", color: "var(--text-2)", whiteSpace: "pre-wrap", marginBottom: "12px" }}>{entry.content}</p>
+                        ) : (
+                          <p style={{ fontSize: "var(--text-caption)", color: "var(--text-3)", fontStyle: "italic", marginBottom: "12px" }}>No additional notes.</p>
+                        )}
+                        {entry.meetingTitle && (
+                          <p style={{ fontSize: "var(--text-caption)", color: "#60a5fa", marginBottom: "12px" }}>
+                            <Link2 style={{ width: "11px", height: "11px", display: "inline", marginRight: "4px" }} />
+                            Meeting: {entry.meetingTitle}
+                          </p>
+                        )}
+                        <div style={{ display: "flex", gap: "8px" }}>
+                          <Button variant="outline" onClick={() => handleStartEdit(entry)}>Edit</Button>
+                          <button
+                            onClick={() => handleDelete(entry.id)}
+                            disabled={deletingId === entry.id}
+                            style={{ display: "inline-flex", alignItems: "center", gap: "4px", padding: "4px 10px", borderRadius: "4px", fontSize: "var(--text-label)", border: "1px solid #7f1d1d", background: "transparent", color: "#f87171", cursor: deletingId === entry.id ? "not-allowed" : "pointer", opacity: deletingId === entry.id ? 0.6 : 1 }}
+                          >
+                            <Trash2 style={{ width: "13px", height: "13px" }} />
+                            {deletingId === entry.id ? "Deleting..." : "Delete"}
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/evidence/evidence-section.tsx
+++ b/components/evidence/evidence-section.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from "react"
 import { Plus, ChevronDown, ChevronRight, Link2, Trash2, Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import { MarkdownTextarea } from "@/components/ui/markdown-textarea"
 import {
   getEvidenceForPerson,

--- a/components/evidence/log-evidence-modal.tsx
+++ b/components/evidence/log-evidence-modal.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { MarkdownTextarea } from "@/components/ui/markdown-textarea"
+import { Link2 } from "lucide-react"
+import { createEvidence, type EvidenceCategory, type EvidenceSentiment } from "@/lib/services/evidence"
+
+const CATEGORY_LABELS: Record<EvidenceCategory, string> = {
+  achievement:        "Achievement",
+  feedback_given:     "Feedback Given",
+  feedback_received:  "Feedback Received",
+  concern:            "Concern",
+  growth:             "Growth",
+  delivery:           "Delivery",
+  behaviour:          "Behaviour",
+  promotion_evidence: "Promotion Evidence",
+  general:            "General",
+}
+
+const SENTIMENT_CONFIG = {
+  positive: { label: "Positive", color: "#4ade80", symbol: "↑" },
+  neutral:  { label: "Neutral",  color: "#9ca3af", symbol: "–" },
+  negative: { label: "Negative", color: "#f87171", symbol: "↓" },
+}
+
+const CATEGORIES = Object.keys(CATEGORY_LABELS) as EvidenceCategory[]
+const SENTIMENTS: EvidenceSentiment[] = ["positive", "neutral", "negative"]
+
+interface LogEvidenceModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  meetingId: string
+  meetingTitle: string
+  meetingDate: string
+  personId: string
+  personName?: string | null
+  /** Used when personId belongs to a 1:1. For Other meetings, show selector. */
+  availablePeople: Array<{ id: string; name: string }>
+}
+
+export function LogEvidenceModal({
+  open,
+  onOpenChange,
+  meetingId,
+  meetingTitle,
+  meetingDate,
+  personId,
+  personName,
+  availablePeople,
+}: LogEvidenceModalProps) {
+  const [category, setCategory] = useState<EvidenceCategory>("general")
+  const [title, setTitle] = useState("")
+  const [content, setContent] = useState("")
+  const [occurredAt, setOccurredAt] = useState(meetingDate)
+  const [sentiment, setSentiment] = useState<EvidenceSentiment>("neutral")
+  const [resolvedPersonId, setResolvedPersonId] = useState(personId)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      setTitle("")
+      setContent("")
+      setCategory("general")
+      setSentiment("neutral")
+      setOccurredAt(meetingDate)
+      setResolvedPersonId(personId)
+    }
+  }, [open, meetingDate, personId])
+
+  const handleSave = async () => {
+    if (!title.trim() || !resolvedPersonId) return
+    setSaving(true)
+    try {
+      await createEvidence({
+        personId: resolvedPersonId,
+        category,
+        title: title.trim(),
+        content: content.trim() || null,
+        occurredAt,
+        meetingId,
+        taskId: null,
+        sentiment,
+        includedInReview: true,
+        reviewPeriodStart: null,
+        reviewPeriodEnd: null,
+      })
+      onOpenChange(false)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent style={{ maxWidth: "520px" }}>
+        <DialogHeader>
+          <DialogTitle>Log as Evidence</DialogTitle>
+          <DialogDescription>
+            Save evidence from this meeting to the Evidence Bank.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Linked meeting indicator */}
+        <div style={{ display: "inline-flex", alignItems: "center", gap: "6px", padding: "6px 10px", borderRadius: "4px", background: "var(--surf-2)", border: "1px solid var(--border-2)", fontSize: "var(--text-caption)", color: "#60a5fa" }}>
+          <Link2 style={{ width: "12px", height: "12px" }} />
+          {meetingTitle} · {new Date(meetingDate).toLocaleDateString("en-GB", { day: "2-digit", month: "short", year: "numeric" })}
+        </div>
+
+        <div style={{ display: "grid", gap: "14px", paddingTop: "4px" }}>
+          {/* Person selector — shown if no pre-resolved person */}
+          {!personId && (
+            <div style={{ display: "grid", gap: "4px" }}>
+              <label className="form-label">Person *</label>
+              <select value={resolvedPersonId} onChange={e => setResolvedPersonId(e.target.value)}
+                style={{ background: "var(--surf-2)", border: "1px solid var(--border-2)", borderRadius: "6px", color: resolvedPersonId ? "var(--text-1)" : "var(--text-3)", padding: "6px 10px", fontSize: "var(--text-label)", cursor: "pointer" }}>
+                <option value="">Select person...</option>
+                {availablePeople.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+            </div>
+          )}
+
+          {personName && (
+            <p style={{ fontSize: "var(--text-caption)", color: "var(--text-3)" }}>
+              Evidence will be logged for <strong style={{ color: "var(--text-1)" }}>{personName}</strong>
+            </p>
+          )}
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 160px", gap: "12px" }}>
+            <div style={{ display: "grid", gap: "4px" }}>
+              <label className="form-label">Category</label>
+              <select value={category} onChange={e => setCategory(e.target.value as EvidenceCategory)}
+                style={{ background: "var(--surf-2)", border: "1px solid var(--border-2)", borderRadius: "6px", color: "var(--text-1)", padding: "6px 10px", fontSize: "var(--text-label)", cursor: "pointer" }}>
+                {CATEGORIES.map(c => <option key={c} value={c}>{CATEGORY_LABELS[c]}</option>)}
+              </select>
+            </div>
+            <div style={{ display: "grid", gap: "4px" }}>
+              <label className="form-label">Date</label>
+              <Input type="date" value={occurredAt} onChange={e => setOccurredAt(e.target.value)} />
+            </div>
+          </div>
+
+          <div style={{ display: "grid", gap: "4px" }}>
+            <label className="form-label">Title *</label>
+            <Input
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              placeholder="Brief description of the evidence..."
+              autoFocus
+            />
+          </div>
+
+          <div style={{ display: "grid", gap: "4px" }}>
+            <label className="form-label">Notes (optional)</label>
+            <MarkdownTextarea value={content} onValueChange={setContent} placeholder="Add context or specifics..." rows={3} />
+          </div>
+
+          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            <label className="form-label" style={{ margin: 0 }}>Sentiment</label>
+            {SENTIMENTS.map(s => {
+              const cfg = SENTIMENT_CONFIG[s]
+              const active = sentiment === s
+              return (
+                <button key={s} type="button" onClick={() => setSentiment(s)}
+                  style={{ padding: "3px 10px", borderRadius: "4px", fontSize: "var(--text-label)", fontWeight: 500, cursor: "pointer", border: `1px solid ${active ? cfg.color + "60" : "var(--border-2)"}`, background: active ? cfg.color + "15" : "var(--surf-2)", color: active ? cfg.color : "var(--text-3)" }}>
+                  {cfg.symbol} {cfg.label}
+                </button>
+              )
+            })}
+          </div>
+
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: "8px", paddingTop: "4px" }}>
+            <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+            <Button onClick={handleSave} disabled={!title.trim() || (!personId && !resolvedPersonId) || saving}>
+              {saving ? "Saving..." : "Save Evidence"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/follow-ups/follow-up-form.tsx
+++ b/components/follow-ups/follow-up-form.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { useState } from 'react'
+import { X } from 'lucide-react'
+import { createFollowUp } from '@/lib/services/follow-ups'
+import type { FollowUpSourceType } from '@/lib/services/follow-ups'
+
+interface FollowUpFormProps {
+  personId: string
+  personName: string
+  sourceType?: FollowUpSourceType
+  sourceId?: string
+  defaultTitle?: string
+  onSaved: () => void
+  onCancel: () => void
+}
+
+export function FollowUpForm({
+  personId,
+  personName,
+  sourceType,
+  sourceId,
+  defaultTitle = '',
+  onSaved,
+  onCancel,
+}: FollowUpFormProps) {
+  const [title, setTitle] = useState(defaultTitle)
+  const [description, setDescription] = useState('')
+  const [dueDate, setDueDate] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSave = async () => {
+    if (!title.trim()) { setError('Title required'); return }
+    setSaving(true)
+    setError(null)
+    try {
+      await createFollowUp({
+        personId,
+        title: title.trim(),
+        description: description.trim() || null,
+        sourceType: sourceType ?? 'manual',
+        sourceId: sourceId ?? null,
+        status: 'open',
+        dueDate: dueDate || null,
+      })
+      onSaved()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save')
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+      onClick={onCancel}
+    >
+      <div
+        style={{
+          background: 'var(--surf-2)',
+          border: '1px solid var(--border-2)',
+          borderRadius: '8px',
+          padding: '20px',
+          width: '400px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '14px',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ fontSize: 'var(--text-body)', fontWeight: 600, color: 'var(--text-1)' }}>
+            Add follow-up for {personName}
+          </span>
+          <button onClick={onCancel} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-3)', display: 'flex' }}>
+            <X style={{ width: '14px', height: '14px' }} />
+          </button>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <label className="form-label">Title</label>
+          <input
+            autoFocus
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            placeholder="What did you commit to?"
+            style={{
+              background: 'var(--surf-3)',
+              border: '1px solid var(--border-2)',
+              borderRadius: '4px',
+              color: 'var(--text-1)',
+              fontSize: 'var(--text-body)',
+              padding: '7px 10px',
+              fontFamily: 'var(--font-sans)',
+              outline: 'none',
+            }}
+          />
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <label className="form-label">Description (optional)</label>
+          <textarea
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder="Additional context..."
+            rows={3}
+            style={{
+              background: 'var(--surf-3)',
+              border: '1px solid var(--border-2)',
+              borderRadius: '4px',
+              color: 'var(--text-1)',
+              fontSize: 'var(--text-meta)',
+              padding: '7px 10px',
+              resize: 'none',
+              fontFamily: 'var(--font-sans)',
+              outline: 'none',
+            }}
+          />
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <label className="form-label">Due date (optional)</label>
+          <input
+            type="date"
+            value={dueDate}
+            onChange={e => setDueDate(e.target.value)}
+            style={{
+              background: 'var(--surf-3)',
+              border: '1px solid var(--border-2)',
+              borderRadius: '4px',
+              color: 'var(--text-1)',
+              fontSize: 'var(--text-meta)',
+              padding: '6px 10px',
+              fontFamily: 'var(--font-sans)',
+              outline: 'none',
+            }}
+          />
+        </div>
+
+        {error && <p style={{ fontSize: 'var(--text-meta)', color: '#ff6b6b', margin: 0 }}>{error}</p>}
+
+        <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+          <button
+            onClick={onCancel}
+            style={{
+              background: 'var(--surf-3)',
+              border: '1px solid var(--border-2)',
+              borderRadius: '4px',
+              color: 'var(--text-2)',
+              fontSize: 'var(--text-meta)',
+              padding: '6px 14px',
+              cursor: 'pointer',
+              fontFamily: 'var(--font-sans)',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            style={{
+              background: 'var(--surf-3)',
+              border: '1px solid #00f058',
+              borderRadius: '4px',
+              color: '#00f058',
+              fontSize: 'var(--text-meta)',
+              fontWeight: 600,
+              padding: '6px 14px',
+              cursor: saving ? 'not-allowed' : 'pointer',
+              opacity: saving ? 0.7 : 1,
+              fontFamily: 'var(--font-sans)',
+            }}
+          >
+            {saving ? 'Saving...' : 'Save follow-up'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/follow-ups/follow-up-list.tsx
+++ b/components/follow-ups/follow-up-list.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { Check, X, ExternalLink, ChevronDown, ChevronRight } from 'lucide-react'
-import { completeFollowUp, cancelFollowUp, deleteFollowUp, type FollowUp } from '@/lib/services/follow-ups'
+import { completeFollowUp, cancelFollowUp, type FollowUp } from '@/lib/services/follow-ups'
 
 interface FollowUpListProps {
   followUps: FollowUp[]

--- a/components/follow-ups/follow-up-list.tsx
+++ b/components/follow-ups/follow-up-list.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Check, X, ExternalLink, ChevronDown, ChevronRight } from 'lucide-react'
+import { completeFollowUp, cancelFollowUp, deleteFollowUp, type FollowUp } from '@/lib/services/follow-ups'
+
+interface FollowUpListProps {
+  followUps: FollowUp[]
+  onChanged: () => void
+  showPerson?: boolean
+}
+
+function ageDays(dateStr: string): number {
+  const created = new Date(dateStr)
+  const today = new Date()
+  return Math.floor((today.getTime() - created.getTime()) / (24 * 60 * 60 * 1000))
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+}
+
+function isOverdue(fu: FollowUp): boolean {
+  if (!fu.dueDate || fu.status !== 'open') return false
+  return fu.dueDate < new Date().toISOString().split('T')[0]
+}
+
+function StatusBadge({ status, overdue }: { status: FollowUp['status']; overdue: boolean }) {
+  if (status === 'completed') {
+    return (
+      <span style={{ fontSize: 'var(--text-caption)', fontWeight: 600, color: '#00f058', background: '#0d1f14', border: '1px solid #1a3a25', borderRadius: '4px', padding: '2px 6px' }}>
+        Done
+      </span>
+    )
+  }
+  if (status === 'cancelled') {
+    return (
+      <span style={{ fontSize: 'var(--text-caption)', color: 'var(--text-3)', background: 'var(--surf-3)', border: '1px solid var(--border-2)', borderRadius: '4px', padding: '2px 6px' }}>
+        Cancelled
+      </span>
+    )
+  }
+  if (overdue) {
+    return (
+      <span style={{ fontSize: 'var(--text-caption)', fontWeight: 600, color: '#ff6b6b', background: '#2a0a0a', border: '1px solid #5a2020', borderRadius: '4px', padding: '2px 6px' }}>
+        Overdue
+      </span>
+    )
+  }
+  return (
+    <span style={{ fontSize: 'var(--text-caption)', color: 'var(--text-2)', background: 'var(--surf-3)', border: '1px solid var(--border-2)', borderRadius: '4px', padding: '2px 6px' }}>
+      Open
+    </span>
+  )
+}
+
+export function FollowUpList({ followUps, onChanged, showPerson = false }: FollowUpListProps) {
+  const [showCompleted, setShowCompleted] = useState(false)
+
+  const open = followUps.filter(f => f.status === 'open')
+  const closed = followUps.filter(f => f.status !== 'open')
+
+  const handleComplete = async (id: string) => {
+    await completeFollowUp(id)
+    onChanged()
+  }
+
+  const handleCancel = async (id: string) => {
+    await cancelFollowUp(id)
+    onChanged()
+  }
+
+  if (followUps.length === 0) {
+    return (
+      <p style={{ fontSize: 'var(--text-meta)', color: 'var(--text-3)', margin: 0 }}>
+        No follow-ups
+      </p>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+      {open.map(fu => {
+        const overdue = isOverdue(fu)
+        const age = ageDays(fu.createdAt)
+        return (
+          <div
+            key={fu.id}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '10px',
+              padding: '8px 12px',
+              background: overdue ? '#1a0a0a' : 'var(--surf-2)',
+              border: `1px solid ${overdue ? '#3a1515' : 'var(--border-1)'}`,
+              borderRadius: '5px',
+            }}
+          >
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 'var(--text-meta)', color: 'var(--text-1)', fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {fu.title}
+              </div>
+              <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginTop: '2px', flexWrap: 'wrap' }}>
+                {showPerson && fu.personName && (
+                  <Link href={`/people/${fu.personId}`} style={{ fontSize: 'var(--text-caption)', color: 'var(--text-2)', textDecoration: 'none', display: 'flex', alignItems: 'center', gap: '3px' }}>
+                    {fu.personName} <ExternalLink style={{ width: '9px', height: '9px' }} />
+                  </Link>
+                )}
+                <span style={{ fontSize: 'var(--text-caption)', color: 'var(--text-3)' }}>
+                  {fu.dueDate ? `Due ${formatDate(fu.dueDate)}` : `${age}d old`}
+                </span>
+                {fu.sourceName && (
+                  <span style={{ fontSize: 'var(--text-caption)', color: 'var(--text-3)' }}>
+                    · from "{fu.sourceName}"
+                  </span>
+                )}
+                <StatusBadge status={fu.status} overdue={overdue} />
+              </div>
+            </div>
+
+            <div style={{ display: 'flex', gap: '4px', flexShrink: 0 }}>
+              <button
+                onClick={() => handleComplete(fu.id)}
+                title="Mark complete"
+                style={{
+                  background: 'none',
+                  border: '1px solid var(--border-2)',
+                  borderRadius: '4px',
+                  color: '#00f058',
+                  cursor: 'pointer',
+                  padding: '3px 6px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '3px',
+                  fontSize: 'var(--text-caption)',
+                }}
+              >
+                <Check style={{ width: '10px', height: '10px' }} /> Done
+              </button>
+              <button
+                onClick={() => handleCancel(fu.id)}
+                title="Cancel"
+                style={{
+                  background: 'none',
+                  border: '1px solid var(--border-2)',
+                  borderRadius: '4px',
+                  color: 'var(--text-3)',
+                  cursor: 'pointer',
+                  padding: '3px 4px',
+                  display: 'flex',
+                  alignItems: 'center',
+                }}
+              >
+                <X style={{ width: '10px', height: '10px' }} />
+              </button>
+            </div>
+          </div>
+        )
+      })}
+
+      {closed.length > 0 && (
+        <div style={{ marginTop: '4px' }}>
+          <button
+            onClick={() => setShowCompleted(s => !s)}
+            style={{
+              background: 'none',
+              border: 'none',
+              color: 'var(--text-3)',
+              fontSize: 'var(--text-caption)',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '4px',
+              padding: '4px 0',
+              fontFamily: 'var(--font-sans)',
+            }}
+          >
+            {showCompleted ? <ChevronDown style={{ width: '11px', height: '11px' }} /> : <ChevronRight style={{ width: '11px', height: '11px' }} />}
+            {closed.length} closed
+          </button>
+          {showCompleted && closed.map(fu => (
+            <div
+              key={fu.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '10px',
+                padding: '6px 12px',
+                opacity: 0.6,
+              }}
+            >
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 'var(--text-meta)', color: 'var(--text-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {fu.title}
+                </div>
+                {fu.completedAt && (
+                  <div style={{ fontSize: 'var(--text-caption)', color: 'var(--text-3)' }}>
+                    Completed {new Date(fu.completedAt).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })}
+                  </div>
+                )}
+              </div>
+              <StatusBadge status={fu.status} overdue={false} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/meeting-form-dialog.tsx
+++ b/components/meeting-form-dialog.tsx
@@ -122,7 +122,7 @@ export function MeetingFormDialog({ open, onOpenChange, meeting, onSave, availab
           attendees: [defaultPerson],
           personName: defaultPerson,
           personId: personData?.id,
-          title: `1:1 with ${defaultPerson}`
+          title: `${initialData.type} with ${defaultPerson}`
         })
         setPersonInput(defaultPerson)
       } else {
@@ -273,7 +273,15 @@ export function MeetingFormDialog({ open, onOpenChange, meeting, onSave, availab
                       <Label htmlFor="type">Meeting Type *</Label>
                       <Select
                         value={formData.type}
-                        onValueChange={(value) => setFormData({ ...formData, type: value })}
+                        onValueChange={(value) => {
+                          const teamBased = ["Team Sync", "Retro", "Planning", "Review", "Standup"]
+                          const newTitle = value === "1:1"
+                            ? (personInput ? `1:1 with ${personInput}` : "")
+                            : teamBased.includes(value)
+                            ? (teamInput ? `${value} - ${teamInput}` : "")
+                            : ""
+                          setFormData({ ...formData, type: value, title: newTitle })
+                        }}
                       >
                         <SelectTrigger>
                           <SelectValue placeholder="Select meeting type" />
@@ -377,7 +385,15 @@ export function MeetingFormDialog({ open, onOpenChange, meeting, onSave, availab
                       <Label htmlFor="type">Meeting Type *</Label>
                       <Select
                         value={formData.type}
-                        onValueChange={(value) => setFormData({ ...formData, type: value })}
+                        onValueChange={(value) => {
+                          const teamBased = ["Team Sync", "Retro", "Planning", "Review", "Standup"]
+                          const newTitle = value === "1:1"
+                            ? (personInput ? `1:1 with ${personInput}` : "")
+                            : teamBased.includes(value)
+                            ? (teamInput ? `${value} - ${teamInput}` : "")
+                            : ""
+                          setFormData({ ...formData, type: value, title: newTitle })
+                        }}
                       >
                         <SelectTrigger>
                           <SelectValue placeholder="Select meeting type" />
@@ -490,7 +506,15 @@ export function MeetingFormDialog({ open, onOpenChange, meeting, onSave, availab
                       <Label htmlFor="type">Meeting Type *</Label>
                       <Select
                         value={formData.type}
-                        onValueChange={(value) => setFormData({ ...formData, type: value })}
+                        onValueChange={(value) => {
+                          const teamBased = ["Team Sync", "Retro", "Planning", "Review", "Standup"]
+                          const newTitle = value === "1:1"
+                            ? (personInput ? `1:1 with ${personInput}` : "")
+                            : teamBased.includes(value)
+                            ? (teamInput ? `${value} - ${teamInput}` : "")
+                            : ""
+                          setFormData({ ...formData, type: value, title: newTitle })
+                        }}
                       >
                         <SelectTrigger>
                           <SelectValue placeholder="Select meeting type" />

--- a/components/people-table.tsx
+++ b/components/people-table.tsx
@@ -4,6 +4,7 @@ import { DataTable, ColumnDef, FilterDef } from "@/components/ui/data-table"
 import { Pencil, Trash2, UserX, UserCheck } from "lucide-react"
 import { type Person } from "@/lib/services/people"
 import { LEVEL_BADGE } from "@/lib/badge-styles"
+import { scoreToColor } from "@/lib/signals/types"
 
 export type { Person }
 
@@ -14,6 +15,7 @@ interface PeopleTableProps {
   onDelete: (person: Person) => void
   onToggleStatus: (person: Person) => void
   onQuickAdd: () => void
+  attentionScores?: Record<string, number>
 }
 
 function LevelChip({ level }: { level: string }) {
@@ -46,6 +48,7 @@ export function PeopleTable({
   onDelete,
   onToggleStatus,
   onQuickAdd,
+  attentionScores = {},
 }: PeopleTableProps) {
   const columns: ColumnDef<Person>[] = [
     {
@@ -80,10 +83,25 @@ export function PeopleTable({
       accessorKey: "name",
       cell: (person) => {
         const isInactive = person.status === "inactive"
+        const score = attentionScores[person.id] ?? 0
         return (
-          <span style={{ fontWeight: 500, fontSize: "var(--text-meta)", color: isInactive ? "var(--text-3)" : "var(--text-1)" }}>
-            {person.name}
-          </span>
+          <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+            {score > 0 && (
+              <span
+                title={`Attention score: ${score}`}
+                style={{
+                  width: "7px",
+                  height: "7px",
+                  borderRadius: "50%",
+                  background: scoreToColor(score),
+                  flexShrink: 0,
+                }}
+              />
+            )}
+            <span style={{ fontWeight: 500, fontSize: "var(--text-meta)", color: isInactive ? "var(--text-3)" : "var(--text-1)" }}>
+              {person.name}
+            </span>
+          </div>
         )
       },
     },

--- a/components/review/dismiss-dialog.tsx
+++ b/components/review/dismiss-dialog.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useState } from 'react'
+import { X } from 'lucide-react'
+
+interface DismissDialogProps {
+  onConfirm: (note: string) => void
+  onCancel: () => void
+}
+
+export function DismissDialog({ onConfirm, onCancel }: DismissDialogProps) {
+  const [note, setNote] = useState('')
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+      onClick={onCancel}
+    >
+      <div
+        style={{
+          background: 'var(--surf-2)',
+          border: '1px solid var(--border-2)',
+          borderRadius: '8px',
+          padding: '20px',
+          width: '360px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '12px',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ fontSize: 'var(--text-body)', fontWeight: 600, color: 'var(--text-1)' }}>
+            Dismiss item
+          </span>
+          <button onClick={onCancel} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-3)', display: 'flex' }}>
+            <X style={{ width: '14px', height: '14px' }} />
+          </button>
+        </div>
+
+        <textarea
+          value={note}
+          onChange={e => setNote(e.target.value)}
+          placeholder="Optional: why are you dismissing this? (e.g. on holiday this week)"
+          rows={3}
+          style={{
+            background: 'var(--surf-3)',
+            border: '1px solid var(--border-2)',
+            borderRadius: '4px',
+            color: 'var(--text-1)',
+            fontSize: 'var(--text-meta)',
+            padding: '8px 10px',
+            resize: 'none',
+            fontFamily: 'var(--font-sans)',
+            outline: 'none',
+          }}
+        />
+
+        <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+          <button
+            onClick={onCancel}
+            style={{
+              background: 'var(--surf-3)',
+              border: '1px solid var(--border-2)',
+              borderRadius: '4px',
+              color: 'var(--text-2)',
+              fontSize: 'var(--text-meta)',
+              padding: '6px 12px',
+              cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => onConfirm(note)}
+            style={{
+              background: 'var(--surf-3)',
+              border: '1px solid var(--border-2)',
+              borderRadius: '4px',
+              color: 'var(--text-1)',
+              fontSize: 'var(--text-meta)',
+              padding: '6px 12px',
+              cursor: 'pointer',
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/review/review-section.tsx
+++ b/components/review/review-section.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { useState } from 'react'
+import { ChevronDown, ChevronRight, CheckCircle } from 'lucide-react'
+
+interface ReviewSectionProps {
+  title: string
+  signalCount: number
+  criticalCount?: number
+  warningCount?: number
+  isReviewed: boolean
+  onMarkReviewed: (reviewed: boolean) => void
+  children: React.ReactNode
+  emptyMessage?: string
+}
+
+export function ReviewSection({
+  title,
+  signalCount,
+  criticalCount = 0,
+  warningCount = 0,
+  isReviewed,
+  onMarkReviewed,
+  children,
+  emptyMessage,
+}: ReviewSectionProps) {
+  const [expanded, setExpanded] = useState(true)
+
+  return (
+    <div
+      style={{
+        background: 'var(--surf)',
+        border: `1px solid ${isReviewed ? '#1a3a25' : 'var(--border-1)'}`,
+        borderRadius: '8px',
+        overflow: 'hidden',
+        transition: 'border-color 0.2s',
+      }}
+    >
+      {/* Section header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '10px',
+          padding: '12px 16px',
+          background: isReviewed ? '#0f1f15' : 'var(--surf-2)',
+          cursor: 'pointer',
+          userSelect: 'none',
+        }}
+        onClick={() => setExpanded(e => !e)}
+      >
+        <span style={{ color: 'var(--text-3)', display: 'flex', alignItems: 'center' }}>
+          {expanded
+            ? <ChevronDown style={{ width: '14px', height: '14px' }} />
+            : <ChevronRight style={{ width: '14px', height: '14px' }} />
+          }
+        </span>
+
+        <span style={{ flex: 1, fontSize: 'var(--text-body)', fontWeight: 600, color: 'var(--text-1)' }}>
+          {title}
+        </span>
+
+        {/* Signal badges */}
+        {!isReviewed && signalCount > 0 && (
+          <span style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+            {criticalCount > 0 && (
+              <span style={{
+                fontSize: 'var(--text-caption)',
+                fontWeight: 600,
+                background: '#3a1515',
+                color: '#ff6b6b',
+                border: '1px solid #5a2020',
+                borderRadius: '4px',
+                padding: '2px 6px',
+              }}>
+                {criticalCount} critical
+              </span>
+            )}
+            {warningCount > 0 && (
+              <span style={{
+                fontSize: 'var(--text-caption)',
+                fontWeight: 600,
+                background: '#2a2010',
+                color: '#ffa94d',
+                border: '1px solid #4a3820',
+                borderRadius: '4px',
+                padding: '2px 6px',
+              }}>
+                {warningCount} warning
+              </span>
+            )}
+          </span>
+        )}
+
+        {isReviewed && (
+          <span style={{ fontSize: 'var(--text-meta)', color: '#00f058', display: 'flex', alignItems: 'center', gap: '4px' }}>
+            <CheckCircle style={{ width: '13px', height: '13px' }} />
+            Reviewed
+          </span>
+        )}
+
+        {/* Mark reviewed toggle */}
+        <div
+          onClick={e => { e.stopPropagation(); onMarkReviewed(!isReviewed) }}
+          style={{
+            width: '18px',
+            height: '18px',
+            borderRadius: '4px',
+            border: `2px solid ${isReviewed ? '#00f058' : 'var(--border-2)'}`,
+            background: isReviewed ? '#00f058' : 'transparent',
+            cursor: 'pointer',
+            flexShrink: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          title={isReviewed ? 'Unmark as reviewed' : 'Mark as reviewed'}
+        >
+          {isReviewed && (
+            <svg width="10" height="8" viewBox="0 0 10 8" fill="none">
+              <path d="M1 4l3 3 5-6" stroke="#000" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          )}
+        </div>
+      </div>
+
+      {/* Section body */}
+      {expanded && (
+        <div style={{ padding: signalCount === 0 ? '16px' : '0' }}>
+          {signalCount === 0 ? (
+            <p style={{ fontSize: 'var(--text-meta)', color: '#00f058', margin: 0 }}>
+              {emptyMessage ?? '✓ All clear'}
+            </p>
+          ) : (
+            children
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -9,7 +9,6 @@ import {
   CheckSquare,
   Users,
   UserCircle,
-  FolderKanban,
   Calendar,
   BookOpen,
   ClipboardCheck,

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -12,17 +12,25 @@ import {
   FolderKanban,
   Calendar,
   BookOpen,
+  ClipboardCheck,
+  ScanSearch,
+  ListChecks,
   ChevronLeft,
   ChevronRight
 } from "lucide-react"
 import { createClient } from "@/lib/supabase/client"
+import { fetchSignalCounts } from "@/lib/hooks/use-weekly-review-signals"
+import { getMondayOfWeek, getWeeklyReview } from "@/lib/services/weekly-review"
 
 const navigation = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard },
+  { name: "Weekly Review", href: "/review", icon: ClipboardCheck },
   { name: "Tasks", href: "/tasks", icon: CheckSquare },
+  { name: "Follow-ups", href: "/follow-ups", icon: ListChecks },
   { name: "Teams", href: "/teams", icon: Users },
   { name: "People", href: "/people", icon: UserCircle },
-  { name: "Projects", href: "/projects", icon: FolderKanban },
+  { name: "People Radar", href: "/radar", icon: ScanSearch },
+  // { name: "Projects", href: "/projects", icon: FolderKanban },
   { name: "Meetings", href: "/meetings", icon: Calendar },
   { name: "Evidence", href: "/evidence", icon: BookOpen },
   // { name: "Career Goals", href: "/career-goals", icon: Target },
@@ -33,11 +41,16 @@ interface SidebarProps {
   onToggle: () => void
 }
 
+type ReviewIndicator = 'critical' | 'warning' | 'complete' | null
+
 export function Sidebar({ isOpen, onToggle }: SidebarProps) {
   const pathname = usePathname()
   const [userName, setUserName] = useState("User")
   const [userAvatar, setUserAvatar] = useState<string | null>(null)
   const [userInitials, setUserInitials] = useState("U")
+  const [reviewIndicator, setReviewIndicator] = useState<ReviewIndicator>(null)
+  const [overdueFollowUps, setOverdueFollowUps] = useState(0)
+  const [radarCritical, setRadarCritical] = useState(0)
 
   useEffect(() => {
     const supabase = createClient()
@@ -49,6 +62,37 @@ export function Sidebar({ isOpen, onToggle }: SidebarProps) {
       setUserAvatar(avatar)
       setUserInitials(name.split(" ").map((n: string) => n[0]).join("").toUpperCase().slice(0, 2))
     })
+  }, [])
+
+  useEffect(() => {
+    async function loadIndicators() {
+      try {
+        const supabase = createClient()
+        const weekStart = getMondayOfWeek()
+        const [review, counts, followUpRes] = await Promise.all([
+          getWeeklyReview(weekStart),
+          fetchSignalCounts(),
+          supabase
+            .from('follow_ups')
+            .select('id', { count: 'exact', head: true })
+            .eq('status', 'open')
+            .lt('due_date', new Date().toISOString().slice(0, 10)),
+        ])
+
+        if (review?.status === "completed") setReviewIndicator("complete")
+        else if (counts.critical > 0) setReviewIndicator("critical")
+        else if (counts.warning > 0) setReviewIndicator("warning")
+        else setReviewIndicator(null)
+
+        setOverdueFollowUps(followUpRes.count ?? 0)
+
+        // radar critical: reuse the signal counts from fetchSignalCounts
+        setRadarCritical(counts.critical)
+      } catch {
+        // non-critical — sidebar indicators are best-effort
+      }
+    }
+    loadIndicators()
   }, [])
 
   return (
@@ -102,32 +146,29 @@ export function Sidebar({ isOpen, onToggle }: SidebarProps) {
       <nav style={{ flex: 1, padding: "4px 10px", display: "flex", flexDirection: "column" }}>
         {navigation.map((item) => {
           const isActive = pathname === item.href
+          const isReview = item.href === "/review"
+          const isFollowUps = item.href === "/follow-ups"
+          const isRadar = item.href === "/radar"
+
+          const dotColor = isReview
+            ? reviewIndicator === "complete" ? "#00f058"
+            : reviewIndicator === "critical" ? "#ff6b6b"
+            : reviewIndicator === "warning" ? "#ffa94d"
+            : null
+            : null
+
+          const badge = isFollowUps && overdueFollowUps > 0
+            ? overdueFollowUps
+            : isRadar && radarCritical > 0
+            ? radarCritical
+            : null
+
           return (
             <Link
               key={item.name}
               href={item.href}
               title={!isOpen ? item.name : undefined}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "7px",
-                padding: isOpen ? "4px 7px" : "4px 6px",
-                borderRadius: "4px",
-                marginBottom: "1px",
-                fontSize: "var(--text-meta)",
-                fontFamily: "var(--font-sans)",
-                color: isActive ? "var(--text-1)" : "var(--text-2)",
-                background: isActive ? "var(--surf-3)" : "transparent",
-                borderRight: isActive ? "2px solid #00f058" : "2px solid transparent",
-                textDecoration: "none",
-                justifyContent: isOpen ? "flex-start" : "center",
-              }}
-              onMouseEnter={e => {
-                if (!isActive) (e.currentTarget as HTMLElement).style.background = "var(--surf-2)"
-              }}
-              onMouseLeave={e => {
-                if (!isActive) (e.currentTarget as HTMLElement).style.background = "transparent"
-              }}
+              className={`nav-item${isActive ? " active" : ""}${!isOpen ? " nav-item-collapsed" : ""}`}
             >
               <item.icon
                 style={{
@@ -137,7 +178,33 @@ export function Sidebar({ isOpen, onToggle }: SidebarProps) {
                   opacity: isActive ? 1 : 0.5,
                 }}
               />
-              {isOpen && item.name}
+              {isOpen && <span style={{ flex: 1 }}>{item.name}</span>}
+              {dotColor && (
+                <span style={{
+                  width: "6px",
+                  height: "6px",
+                  borderRadius: "50%",
+                  background: dotColor,
+                  flexShrink: 0,
+                }} />
+              )}
+              {badge !== null && (
+                <span style={{
+                  background: "#ff6b6b",
+                  color: "#fff",
+                  borderRadius: "10px",
+                  padding: "0 5px",
+                  fontSize: "var(--text-overline)",
+                  fontWeight: 600,
+                  fontFamily: "var(--font-mono)",
+                  lineHeight: "16px",
+                  flexShrink: 0,
+                  minWidth: "16px",
+                  textAlign: "center",
+                }}>
+                  {badge > 99 ? "99+" : badge}
+                </span>
+              )}
             </Link>
           )
         })}
@@ -148,26 +215,8 @@ export function Sidebar({ isOpen, onToggle }: SidebarProps) {
         <Link
           href="/settings"
           title={!isOpen ? "Settings" : undefined}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "7px",
-            padding: "4px 7px",
-            borderRadius: "4px",
-            fontSize: "var(--text-meta)",
-            fontFamily: "var(--font-sans)",
-            color: pathname === "/settings" ? "var(--text-1)" : "var(--text-2)",
-            background: pathname === "/settings" ? "var(--surf-3)" : "transparent",
-            borderRight: pathname === "/settings" ? "2px solid #00f058" : "2px solid transparent",
-            textDecoration: "none",
-            justifyContent: isOpen ? "flex-start" : "center",
-          }}
-          onMouseEnter={e => {
-            if (pathname !== "/settings") (e.currentTarget as HTMLElement).style.background = "var(--surf-2)"
-          }}
-          onMouseLeave={e => {
-            if (pathname !== "/settings") (e.currentTarget as HTMLElement).style.background = "transparent"
-          }}
+          className={`nav-item${pathname === "/settings" ? " active" : ""}${!isOpen ? " nav-item-collapsed" : ""}`}
+          style={{ marginBottom: 0 }}
         >
           {userAvatar ? (
             <img

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -11,6 +11,7 @@ import {
   UserCircle,
   FolderKanban,
   Calendar,
+  BookOpen,
   ChevronLeft,
   ChevronRight
 } from "lucide-react"
@@ -23,6 +24,7 @@ const navigation = [
   { name: "People", href: "/people", icon: UserCircle },
   { name: "Projects", href: "/projects", icon: FolderKanban },
   { name: "Meetings", href: "/meetings", icon: Calendar },
+  { name: "Evidence", href: "/evidence", icon: BookOpen },
   // { name: "Career Goals", href: "/career-goals", icon: Target },
 ]
 

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -12,7 +12,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         <input
           type={type}
           className={cn(
-            "flex h-10 w-full rounded-[5px] bg-[#262626] px-3 py-2 text-sm text-gray-100 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-gray-400 focus-visible:outline-none disabled:cursor-not-allowed",
+            "flex h-10 w-full rounded-[5px] bg-[#262626] px-3 py-2 text-sm text-gray-100 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-gray-400 focus-visible:outline-none disabled:cursor-not-allowed [&[type=date]]:pr-2",
             className
           )}
           ref={ref}

--- a/lib/hooks/__tests__/use-weekly-review-signals.test.ts
+++ b/lib/hooks/__tests__/use-weekly-review-signals.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import { getMondayOfWeek, formatWeekRange } from '../../services/weekly-review'
+
+// Tests for the pure utility functions used by the signals hook
+
+describe('getMondayOfWeek edge cases', () => {
+  it('handles leap year boundary', () => {
+    // 2028-03-01 is a Wednesday (leap year, day after Feb 29)
+    const result = getMondayOfWeek(new Date('2028-03-01'))
+    expect(result).toBe('2028-02-28')
+  })
+
+  it('handles last day of year (Thursday)', () => {
+    // 2026-12-31 is a Thursday
+    const result = getMondayOfWeek(new Date('2026-12-31'))
+    expect(result).toBe('2026-12-28')
+  })
+
+  it('handles first day of year that is a Monday', () => {
+    // 2024-01-01 is a Monday
+    const result = getMondayOfWeek(new Date('2024-01-01'))
+    expect(result).toBe('2024-01-01')
+  })
+
+  it('handles Saturday', () => {
+    // 2026-05-02 is a Saturday
+    const result = getMondayOfWeek(new Date('2026-05-02'))
+    expect(result).toBe('2026-04-27')
+  })
+})
+
+describe('formatWeekRange', () => {
+  it('handles week straddling year boundary', () => {
+    // week starting 2025-12-29 (Mon) ends 2026-01-04 (Sun) — different years
+    const result = formatWeekRange('2025-12-29')
+    // Should contain both Dec and Jan
+    expect(result).toMatch(/Dec/)
+    expect(result).toMatch(/Jan/)
+  })
+
+  it('shows correct month abbreviations', () => {
+    const result = formatWeekRange('2026-04-27')
+    expect(result).toMatch(/Apr/)
+    expect(result).toMatch(/May/)
+  })
+})
+
+describe('Signal severity logic', () => {
+  // Test the daysOverdue threshold logic inline (matches hook implementation)
+  it('overdue task is warning at 1-3 days, critical at 4+', () => {
+    function getSeverity(daysOverdue: number): 'warning' | 'critical' {
+      return daysOverdue >= 4 ? 'critical' : 'warning'
+    }
+    expect(getSeverity(1)).toBe('warning')
+    expect(getSeverity(3)).toBe('warning')
+    expect(getSeverity(4)).toBe('critical')
+    expect(getSeverity(10)).toBe('critical')
+  })
+
+  it('no 1:1 is warning at 14-20 days, critical at 21+', () => {
+    function getSeverity(daysSince: number): 'warning' | 'critical' {
+      return daysSince >= 21 ? 'critical' : 'warning'
+    }
+    expect(getSeverity(14)).toBe('warning')
+    expect(getSeverity(20)).toBe('warning')
+    expect(getSeverity(21)).toBe('critical')
+    expect(getSeverity(30)).toBe('critical')
+  })
+
+  it('unresolved action is info under 7 days, warning 7-13, critical 14+', () => {
+    function getSeverity(daysAgo: number): 'info' | 'warning' | 'critical' {
+      return daysAgo >= 14 ? 'critical' : daysAgo >= 7 ? 'warning' : 'info'
+    }
+    expect(getSeverity(3)).toBe('info')
+    expect(getSeverity(7)).toBe('warning')
+    expect(getSeverity(13)).toBe('warning')
+    expect(getSeverity(14)).toBe('critical')
+  })
+})
+
+describe('Dismissed items exclusion', () => {
+  it('dismissed set key format matches type::id pattern', () => {
+    // Verify the key format used in the hook for dismiss lookup
+    const type = 'overdue_task'
+    const id = 'task-abc-123'
+    const key = `${type}::${id}`
+    expect(key).toBe('overdue_task::task-abc-123')
+
+    const emptyRefKey = `no_recent_1on1::`
+    expect(emptyRefKey).toBe('no_recent_1on1::')
+  })
+
+  it('dismissed set correctly filters out dismissed signals', () => {
+    const dismissed = [
+      { itemType: 'overdue_task', referenceId: 'task-1' },
+      { itemType: 'no_recent_1on1', referenceId: 'person-2' },
+    ]
+    const dismissedSet = new Set(dismissed.map(d => `${d.itemType}::${d.referenceId ?? ''}`))
+    const isDismissed = (type: string, refId: string) => dismissedSet.has(`${type}::${refId}`)
+
+    expect(isDismissed('overdue_task', 'task-1')).toBe(true)
+    expect(isDismissed('overdue_task', 'task-2')).toBe(false)
+    expect(isDismissed('no_recent_1on1', 'person-2')).toBe(true)
+    expect(isDismissed('no_recent_1on1', 'person-3')).toBe(false)
+  })
+})

--- a/lib/hooks/use-person-signals.ts
+++ b/lib/hooks/use-person-signals.ts
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { createClient } from '@/lib/supabase/client'
 import {
   loadSignalData,
   computePeopleSignals,

--- a/lib/hooks/use-person-signals.ts
+++ b/lib/hooks/use-person-signals.ts
@@ -1,0 +1,117 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { createClient } from '@/lib/supabase/client'
+import {
+  loadSignalData,
+  computePeopleSignals,
+  computeFollowUpSignals,
+  buildDismissedSet,
+  sortSignals,
+} from '@/lib/signals/compute'
+import { computeAttentionScore, type Signal } from '@/lib/signals/types'
+
+export interface PersonAttention {
+  personId: string
+  personName: string
+  personRole: string | null
+  signals: Signal[]
+  score: number
+  openFollowUpCount: number
+}
+
+export interface RadarData {
+  people: PersonAttention[]
+  loading: boolean
+  error: string | null
+  refetch: () => void
+}
+
+async function computeRadarData(): Promise<PersonAttention[]> {
+  const today = new Date()
+  const dismissedSet = buildDismissedSet([])
+
+  const data = await loadSignalData()
+
+  const allPeopleSignals = computePeopleSignals(data, dismissedSet, today)
+  const allFollowUpSignals = computeFollowUpSignals(data.openFollowUps, dismissedSet, today)
+  const allSignals = [...allPeopleSignals, ...allFollowUpSignals]
+
+  // Count open follow-ups per person
+  const openFollowUpsByPerson: Record<string, number> = {}
+  for (const fu of data.openFollowUps) {
+    if (!openFollowUpsByPerson[fu.person_id]) openFollowUpsByPerson[fu.person_id] = 0
+    openFollowUpsByPerson[fu.person_id]++
+  }
+
+  return data.activePeople.map(person => {
+    const personSignals = sortSignals(allSignals.filter(s => s.personId === person.id))
+    return {
+      personId: person.id,
+      personName: person.full_name,
+      personRole: person.role ?? null,
+      signals: personSignals,
+      score: computeAttentionScore(personSignals),
+      openFollowUpCount: openFollowUpsByPerson[person.id] ?? 0,
+    }
+  }).sort((a, b) => b.score - a.score)
+}
+
+export function usePersonSignals(personId: string): {
+  signals: Signal[]
+  score: number
+  loading: boolean
+} {
+  const [signals, setSignals] = useState<Signal[]>([])
+  const [score, setScore] = useState(0)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      try {
+        const data = await loadSignalData()
+        const today = new Date()
+        const dismissedSet = buildDismissedSet([])
+
+        const allPeopleSignals = computePeopleSignals(data, dismissedSet, today)
+        const allFollowUpSignals = computeFollowUpSignals(data.openFollowUps, dismissedSet, today)
+        const personSignals = sortSignals(
+          [...allPeopleSignals, ...allFollowUpSignals].filter(s => s.personId === personId)
+        )
+        setSignals(personSignals)
+        setScore(computeAttentionScore(personSignals))
+      } catch {
+        // non-critical for detail page
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [personId])
+
+  return { signals, score, loading }
+}
+
+export function useRadar(): RadarData {
+  const [people, setPeople] = useState<PersonAttention[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetch = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await computeRadarData()
+      setPeople(result)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load radar data')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { fetch() }, [fetch])
+
+  return { people, loading, error, refetch: fetch }
+}

--- a/lib/hooks/use-weekly-review-signals.ts
+++ b/lib/hooks/use-weekly-review-signals.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import {
   loadSignalData,
   computeTaskSignals,
@@ -47,6 +47,11 @@ export function useWeeklyReviewSignals(dismissedItems: DismissedItem[]): Signals
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
+  const dismissedKey = useMemo(
+    () => dismissedItems.map(d => d.id).join(','),
+    [dismissedItems]
+  )
+
   const fetch = useCallback(async () => {
     setLoading(true)
     setError(null)
@@ -59,7 +64,7 @@ export function useWeeklyReviewSignals(dismissedItems: DismissedItem[]): Signals
       setLoading(false)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(dismissedItems.map(d => d.id))])
+  }, [dismissedKey])
 
   useEffect(() => {
     fetch()

--- a/lib/hooks/use-weekly-review-signals.ts
+++ b/lib/hooks/use-weekly-review-signals.ts
@@ -1,0 +1,89 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import {
+  loadSignalData,
+  computeTaskSignals,
+  computePeopleSignals,
+  computeFollowUpSignals,
+  computeActionItemSignals,
+  sortSignals,
+  buildDismissedSet,
+} from '@/lib/signals/compute'
+import type { Signal } from '@/lib/signals/types'
+import type { DismissedItem } from '@/lib/services/weekly-review'
+
+// Re-export shared types so existing consumers keep working without import changes
+export type { SignalSeverity, SignalType, Signal as ReviewSignal } from '@/lib/signals/types'
+
+export interface SignalsData {
+  signals: Signal[]
+  loading: boolean
+  error: string | null
+  refetch: () => void
+}
+
+async function computeAllSignals(dismissedItems: DismissedItem[]): Promise<Signal[]> {
+  const today = new Date()
+  const dismissedSet = buildDismissedSet(
+    dismissedItems.map(d => ({ itemType: d.itemType, referenceId: d.referenceId }))
+  )
+
+  const data = await loadSignalData()
+
+  const [taskSignals, peopleSignals, actionSignals] = await Promise.all([
+    Promise.resolve(computeTaskSignals(data, dismissedSet, today)),
+    Promise.resolve(computePeopleSignals(data, dismissedSet, today)),
+    computeActionItemSignals(data.recentMeetings, dismissedSet, today),
+  ])
+
+  const followUpSignals = computeFollowUpSignals(data.openFollowUps, dismissedSet, today)
+
+  return sortSignals([...taskSignals, ...peopleSignals, ...actionSignals, ...followUpSignals])
+}
+
+export function useWeeklyReviewSignals(dismissedItems: DismissedItem[]): SignalsData {
+  const [signals, setSignals] = useState<Signal[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetch = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await computeAllSignals(dismissedItems)
+      setSignals(result)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load signals')
+    } finally {
+      setLoading(false)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(dismissedItems.map(d => d.id))])
+
+  useEffect(() => {
+    fetch()
+  }, [fetch])
+
+  return { signals, loading, error, refetch: fetch }
+}
+
+/** Non-hook version for sidebar indicator */
+export async function fetchSignalCounts(): Promise<{
+  critical: number
+  warning: number
+  info: number
+  total: number
+}> {
+  try {
+    const result = await computeAllSignals([])
+    return {
+      critical: result.filter(s => s.severity === 'critical').length,
+      warning: result.filter(s => s.severity === 'warning').length,
+      info: result.filter(s => s.severity === 'info').length,
+      total: result.length,
+    }
+  } catch {
+    return { critical: 0, warning: 0, info: 0, total: 0 }
+  }
+}

--- a/lib/services/__tests__/evidence.test.ts
+++ b/lib/services/__tests__/evidence.test.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  getEvidenceForPerson,
+  getEvidenceForPersonInPeriod,
+  getAllEvidence,
+  createEvidence,
+  updateEvidence,
+  deleteEvidence,
+  getReviewCycles,
+  createReviewCycle,
+  getReviewSummary,
+  upsertReviewSummary,
+} from '../evidence'
+import { mockSupabaseClient } from '../../../test/mocks/supabase'
+
+const mockEvidenceRow = {
+  id: 'ev-1',
+  owning_user_id: 'test-user-id',
+  person_id: 'person-1',
+  category: 'achievement' as const,
+  title: 'Shipped new feature',
+  content: 'Delivered ahead of schedule',
+  occurred_at: '2026-03-15',
+  meeting_id: null,
+  task_id: null,
+  sentiment: 'positive' as const,
+  review_period_start: null,
+  review_period_end: null,
+  included_in_review: true,
+  created_at: '2026-03-15T10:00:00Z',
+  updated_at: '2026-03-15T10:00:00Z',
+  person: { full_name: 'Alice Smith' },
+  meeting: null,
+  task: null,
+}
+
+const mockCycleRow = {
+  id: 'cycle-1',
+  owning_user_id: 'test-user-id',
+  name: 'H1 2026',
+  start_date: '2026-01-01',
+  end_date: '2026-06-30',
+  status: 'active' as const,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const mockSummaryRow = {
+  id: 'sum-1',
+  owning_user_id: 'test-user-id',
+  person_id: 'person-1',
+  review_cycle_id: 'cycle-1',
+  period_start: '2026-01-01',
+  period_end: '2026-06-30',
+  summary_text: 'Great performance',
+  manager_notes: 'Private note',
+  created_at: '2026-03-01T00:00:00Z',
+  updated_at: '2026-03-01T00:00:00Z',
+}
+
+describe('Evidence Service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Restore authenticated user after any test that overrides it
+    mockSupabaseClient.auth.getUser = vi.fn().mockResolvedValue({
+      data: { user: { id: 'test-user-id', email: 'test@example.com' } },
+      error: null,
+    })
+  })
+
+  // ── getEvidenceForPerson ──────────────────────────────────────────────────
+
+  describe('getEvidenceForPerson', () => {
+    it('should fetch evidence for a person sorted by occurred_at descending', async () => {
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: [mockEvidenceRow], error: null }),
+          }),
+        }),
+      })
+
+      const result = await getEvidenceForPerson('person-1')
+
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('evidence_entries')
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('ev-1')
+      expect(result[0].personId).toBe('person-1')
+      expect(result[0].personName).toBe('Alice Smith')
+      expect(result[0].category).toBe('achievement')
+      expect(result[0].title).toBe('Shipped new feature')
+      expect(result[0].sentiment).toBe('positive')
+      expect(result[0].includedInReview).toBe(true)
+    })
+
+    it('should throw on database error', async () => {
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+          }),
+        }),
+      })
+
+      await expect(getEvidenceForPerson('person-1')).rejects.toThrow('DB error')
+    })
+  })
+
+  // ── getEvidenceForPersonInPeriod ─────────────────────────────────────────
+
+  describe('getEvidenceForPersonInPeriod', () => {
+    it('should filter by person and date range', async () => {
+      const chainMock = {
+        eq: vi.fn().mockReturnThis(),
+        gte: vi.fn().mockReturnThis(),
+        lte: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: [mockEvidenceRow], error: null }),
+      }
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue(chainMock),
+      })
+
+      const result = await getEvidenceForPersonInPeriod('person-1', '2026-01-01', '2026-06-30')
+
+      expect(chainMock.eq).toHaveBeenCalledWith('person_id', 'person-1')
+      expect(chainMock.gte).toHaveBeenCalledWith('occurred_at', '2026-01-01')
+      expect(chainMock.lte).toHaveBeenCalledWith('occurred_at', '2026-06-30')
+      expect(result).toHaveLength(1)
+    })
+  })
+
+  // ── getAllEvidence ────────────────────────────────────────────────────────
+
+  describe('getAllEvidence', () => {
+    it('should fetch all evidence entries', async () => {
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          order: vi.fn().mockResolvedValue({ data: [mockEvidenceRow], error: null }),
+        }),
+      })
+
+      const result = await getAllEvidence()
+
+      expect(result).toHaveLength(1)
+      expect(result[0].title).toBe('Shipped new feature')
+    })
+  })
+
+  // ── createEvidence ───────────────────────────────────────────────────────
+
+  describe('createEvidence', () => {
+    it('should create evidence with authenticated user id', async () => {
+      const insertMock = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: mockEvidenceRow, error: null }),
+        }),
+      })
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        insert: insertMock,
+      })
+
+      const result = await createEvidence({
+        personId: 'person-1',
+        category: 'achievement',
+        title: 'Shipped new feature',
+        content: 'Delivered ahead of schedule',
+        occurredAt: '2026-03-15',
+        meetingId: null,
+        taskId: null,
+        sentiment: 'positive',
+        includedInReview: true,
+        reviewPeriodStart: null,
+        reviewPeriodEnd: null,
+      })
+
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('evidence_entries')
+      expect(insertMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owning_user_id: 'test-user-id',
+          person_id: 'person-1',
+          category: 'achievement',
+          title: 'Shipped new feature',
+          sentiment: 'positive',
+        })
+      )
+      expect(result.id).toBe('ev-1')
+    })
+
+    it('should throw when not authenticated', async () => {
+      mockSupabaseClient.auth.getUser = vi.fn().mockResolvedValue({
+        data: { user: null }, error: null,
+      })
+
+      await expect(createEvidence({
+        personId: 'person-1',
+        category: 'general',
+        title: 'Test',
+        content: null,
+        occurredAt: '2026-03-15',
+        meetingId: null,
+        taskId: null,
+        sentiment: null,
+        includedInReview: true,
+        reviewPeriodStart: null,
+        reviewPeriodEnd: null,
+      })).rejects.toThrow('Not authenticated')
+    })
+
+    it('should only accept valid categories', async () => {
+      const validCategories = [
+        'achievement', 'feedback_given', 'feedback_received', 'concern',
+        'growth', 'delivery', 'behaviour', 'promotion_evidence', 'general',
+      ]
+      // All valid — just verify the type constraint is correct at TS level
+      expect(validCategories).toHaveLength(9)
+    })
+  })
+
+  // ── updateEvidence ───────────────────────────────────────────────────────
+
+  describe('updateEvidence', () => {
+    it('should update evidence entry fields', async () => {
+      const updatedRow = { ...mockEvidenceRow, title: 'Updated title', sentiment: 'neutral' as const }
+      const updateMock = vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: updatedRow, error: null }),
+          }),
+        }),
+      })
+      mockSupabaseClient.from = vi.fn().mockReturnValue({ update: updateMock })
+
+      const result = await updateEvidence('ev-1', { title: 'Updated title', sentiment: 'neutral' })
+
+      expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Updated title', sentiment: 'neutral' }))
+      expect(result.title).toBe('Updated title')
+      expect(result.sentiment).toBe('neutral')
+    })
+
+    it('should map UI fields to DB column names', async () => {
+      const updateMock = vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: mockEvidenceRow, error: null }),
+          }),
+        }),
+      })
+      mockSupabaseClient.from = vi.fn().mockReturnValue({ update: updateMock })
+
+      await updateEvidence('ev-1', { occurredAt: '2026-04-01', includedInReview: false })
+
+      expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({
+        occurred_at: '2026-04-01',
+        included_in_review: false,
+      }))
+    })
+  })
+
+  // ── deleteEvidence ───────────────────────────────────────────────────────
+
+  describe('deleteEvidence', () => {
+    it('should delete evidence entry by id', async () => {
+      const deleteMock = vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      })
+      mockSupabaseClient.from = vi.fn().mockReturnValue({ delete: deleteMock })
+
+      await deleteEvidence('ev-1')
+
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('evidence_entries')
+      expect(deleteMock).toHaveBeenCalled()
+    })
+
+    it('should throw on delete error', async () => {
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        delete: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: { message: 'Delete failed' } }),
+        }),
+      })
+
+      await expect(deleteEvidence('ev-1')).rejects.toThrow('Delete failed')
+    })
+  })
+
+  // ── getReviewCycles ──────────────────────────────────────────────────────
+
+  describe('getReviewCycles', () => {
+    it('should fetch review cycles sorted by start_date descending', async () => {
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          order: vi.fn().mockResolvedValue({ data: [mockCycleRow], error: null }),
+        }),
+      })
+
+      const result = await getReviewCycles()
+
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('review_cycles')
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('cycle-1')
+      expect(result[0].name).toBe('H1 2026')
+      expect(result[0].startDate).toBe('2026-01-01')
+      expect(result[0].endDate).toBe('2026-06-30')
+      expect(result[0].status).toBe('active')
+    })
+  })
+
+  // ── createReviewCycle ────────────────────────────────────────────────────
+
+  describe('createReviewCycle', () => {
+    it('should create review cycle with authenticated user id', async () => {
+      const insertMock = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: mockCycleRow, error: null }),
+        }),
+      })
+      mockSupabaseClient.from = vi.fn().mockReturnValue({ insert: insertMock })
+
+      const result = await createReviewCycle({
+        name: 'H1 2026',
+        startDate: '2026-01-01',
+        endDate: '2026-06-30',
+        status: 'active',
+      })
+
+      expect(insertMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owning_user_id: 'test-user-id',
+          name: 'H1 2026',
+          start_date: '2026-01-01',
+          end_date: '2026-06-30',
+        })
+      )
+      expect(result.name).toBe('H1 2026')
+    })
+  })
+
+  // ── getReviewSummary ─────────────────────────────────────────────────────
+
+  describe('getReviewSummary', () => {
+    it('should return summary for matching person and period', async () => {
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: mockSummaryRow, error: null }),
+        }),
+      })
+
+      const result = await getReviewSummary('person-1', '2026-01-01', '2026-06-30')
+
+      expect(result).not.toBeNull()
+      expect(result!.id).toBe('sum-1')
+      expect(result!.summaryText).toBe('Great performance')
+      expect(result!.managerNotes).toBe('Private note')
+    })
+
+    it('should return null when no summary exists', async () => {
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      })
+
+      const result = await getReviewSummary('person-1', '2026-01-01', '2026-06-30')
+      expect(result).toBeNull()
+    })
+  })
+
+  // ── upsertReviewSummary ──────────────────────────────────────────────────
+
+  describe('upsertReviewSummary', () => {
+    it('should upsert review summary with conflict resolution', async () => {
+      const upsertMock = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: mockSummaryRow, error: null }),
+        }),
+      })
+      mockSupabaseClient.from = vi.fn().mockReturnValue({ upsert: upsertMock })
+
+      const result = await upsertReviewSummary({
+        personId: 'person-1',
+        reviewCycleId: 'cycle-1',
+        periodStart: '2026-01-01',
+        periodEnd: '2026-06-30',
+        summaryText: 'Great performance',
+        managerNotes: 'Private note',
+      })
+
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('review_summaries')
+      expect(upsertMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owning_user_id: 'test-user-id',
+          person_id: 'person-1',
+          period_start: '2026-01-01',
+          period_end: '2026-06-30',
+          summary_text: 'Great performance',
+        }),
+        expect.objectContaining({ onConflict: expect.any(String) })
+      )
+      expect(result.summaryText).toBe('Great performance')
+    })
+  })
+})

--- a/lib/services/__tests__/follow-ups.test.ts
+++ b/lib/services/__tests__/follow-ups.test.ts
@@ -12,10 +12,9 @@ import {
   deleteFollowUp,
   markFollowUpSurfaced,
   markFollowUpsSurfaced,
-  type FollowUp,
 } from '../follow-ups'
 
-const makeRow = (overrides: Partial<ReturnType<typeof baseRow>> = {}) => ({
+const makeRow = (overrides: Record<string, unknown> = {}) => ({
   ...baseRow(),
   ...overrides,
 })

--- a/lib/services/__tests__/follow-ups.test.ts
+++ b/lib/services/__tests__/follow-ups.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import '../../../test/mocks/supabase'
+import { mockSupabaseClient } from '../../../test/mocks/supabase'
+import {
+  getFollowUpsForPerson,
+  getAllFollowUps,
+  getOpenFollowUps,
+  createFollowUp,
+  updateFollowUp,
+  completeFollowUp,
+  cancelFollowUp,
+  deleteFollowUp,
+  markFollowUpSurfaced,
+  markFollowUpsSurfaced,
+  type FollowUp,
+} from '../follow-ups'
+
+const makeRow = (overrides: Partial<ReturnType<typeof baseRow>> = {}) => ({
+  ...baseRow(),
+  ...overrides,
+})
+
+function baseRow() {
+  return {
+    id: 'fu-1',
+    user_id: 'user-1',
+    person_id: 'person-1',
+    title: 'Follow up on sprint velocity',
+    description: null,
+    source_type: null,
+    source_id: null,
+    status: 'open' as const,
+    due_date: null,
+    created_at: '2026-05-01T10:00:00Z',
+    completed_at: null,
+    cancelled_at: null,
+    last_surfaced_at: null,
+    times_surfaced: 0,
+    updated_at: '2026-05-01T10:00:00Z',
+    person: { full_name: 'Alice Smith' },
+    meeting: null,
+  }
+}
+
+function makeMock(data: any, error: any = null) {
+  const chain: any = {
+    select: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data, error }),
+    then: vi.fn((resolve: any) => resolve({ data, error })),
+  }
+  return chain
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getFollowUpsForPerson', () => {
+  it('returns mapped follow-ups for a person', async () => {
+    const row = makeRow()
+    const chain = makeMock([row])
+    vi.spyOn(mockSupabaseClient, 'from').mockReturnValue(chain)
+
+    const result = await getFollowUpsForPerson('person-1')
+
+    expect(mockSupabaseClient.from).toHaveBeenCalledWith('follow_ups')
+    expect(chain.eq).toHaveBeenCalledWith('person_id', 'person-1')
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('fu-1')
+    expect(result[0].personName).toBe('Alice Smith')
+    expect(result[0].status).toBe('open')
+  })
+
+  it('throws on error', async () => {
+    const chain = makeMock(null, { message: 'DB error' })
+    vi.spyOn(mockSupabaseClient, 'from').mockReturnValue(chain)
+    await expect(getFollowUpsForPerson('person-1')).rejects.toThrow('DB error')
+  })
+})
+
+describe('getAllFollowUps', () => {
+  it('returns all follow-ups', async () => {
+    const rows = [makeRow(), makeRow({ id: 'fu-2', person_id: 'person-2' })]
+    const chain = makeMock(rows)
+    vi.spyOn(mockSupabaseClient, 'from').mockReturnValue(chain)
+
+    const result = await getAllFollowUps()
+    expect(result).toHaveLength(2)
+  })
+})
+
+describe('getOpenFollowUps', () => {
+  it('filters to open status', async () => {
+    const chain = makeMock([makeRow()])
+    vi.spyOn(mockSupabaseClient, 'from').mockReturnValue(chain)
+
+    await getOpenFollowUps()
+    expect(chain.eq).toHaveBeenCalledWith('status', 'open')
+  })
+})
+
+describe('createFollowUp', () => {
+  it('inserts with user id and returns mapped follow-up', async () => {
+    const row = makeRow({ source_type: 'meeting', source_id: 'mtg-1', meeting: { title: 'Sprint Retro' } })
+    const chain = makeMock(row)
+    chain.insert = vi.fn().mockReturnThis()
+    chain.select = vi.fn().mockReturnThis()
+    chain.single = vi.fn().mockResolvedValue({ data: row, error: null })
+    vi.spyOn(mockSupabaseClient, 'from').mockReturnValue(chain)
+
+    const result = await createFollowUp({
+      personId: 'person-1',
+      title: 'Follow up on sprint velocity',
+      description: null,
+      sourceType: 'meeting',
+      sourceId: 'mtg-1',
+      status: 'open',
+      dueDate: null,
+    })
+
+    expect(chain.insert).toHaveBeenCalledWith(expect.objectContaining({
+      user_id: 'test-user-id',
+      person_id: 'person-1',
+      title: 'Follow up on sprint velocity',
+      source_type: 'meeting',
+      source_id: 'mtg-1',
+    }))
+    expect(result.sourceName).toBe('Sprint Retro')
+  })
+
+  it('throws when not authenticated', async () => {
+    mockSupabaseClient.auth.getUser = vi.fn().mockResolvedValue({ data: { user: null }, error: null })
+    const chain = makeMock(null)
+    vi.spyOn(mockSupabaseClient, 'from').mockReturnValue(chain)
+
+    await expect(createFollowUp({
+      personId: 'p1', title: 'Test', description: null,
+      sourceType: null, sourceId: null, status: 'open', dueDate: null,
+    })).rejects.toThrow('Not authenticated')
+
+    // restore
+    mockSupabaseClient.auth.getUser = vi.fn().mockResolvedValue({
+      data: { user: { id: 'test-user-id', email: 'test@example.com' } }, error: null,
+    })
+  })
+})
+
+describe('updateFollowUp', () => {
+  it('maps camelCase to snake_case fields', async () => {
+    const row = makeRow({ status: 'completed', completed_at: '2026-05-02T10:00:00Z' })
+    const chain = makeMock(row)
+    chain.update = vi.fn().mockReturnThis()
+    chain.eq = vi.fn().mockReturnThis()
+    chain.select = vi.fn().mockReturnThis()
+    chain.single = vi.fn().mockResolvedValue({ data: row, error: null })
+    vi.spyOn(mockSupabaseClient, 'from').mockReturnValue(chain)
+
+    const result = await updateFollowUp('fu-1', { status: 'completed', dueDate: '2026-05-10' })
+
+    expect(chain.update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'completed',
+      due_date: '2026-05-10',
+      completed_at: expect.any(String),
+    }))
+    expect(result.status).toBe('completed')
+  })
+
+  it('sets cancelled_at when cancelling', async () => {
+    const row = makeRow({ status: 'cancelled', cancelled_at: '2026-05-02T10:00:00Z' })
+    const chain = makeMock(row)
+    chain.update = vi.fn().mockReturnThis()
+    chain.eq = vi.fn().mockReturnThis()
+    chain.select = vi.fn().mockReturnThis()
+    chain.single = vi.fn().mockResolvedValue({ data: row, error: null })
+    vi.spyOn(mockSupabaseClient, 'from').mockReturnValue(chain)
+
+    await updateFollowUp('fu-1', { status: 'cancelled' })
+
+    expect(chain.update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'cancelled',
+      cancelled_at: expect.any(String),
+    }))
+  })
+})
+
+describe('completeFollowUp', () => {
+  it('delegates to updateFollowUp with completed status', async () => {
+    const row = makeRow({ status: 'completed', completed_at: '2026-05-02T10:00:00Z' })
+    const chain = makeMock(row)
+    chain.update = vi.fn().mockReturnThis()
+    chain.eq = vi.fn().mockReturnThis()
+    chain.select = vi.fn().mockReturnThis()
+    chain.single = vi.fn().mockResolvedValue({ data: row, error: null })
+    vi.spyOn(mockSupabaseClient, 'from').mockReturnValue(chain)
+
+    const result = await completeFollowUp('fu-1')
+    expect(result.status).toBe('completed')
+  })
+})
+
+describe('cancelFollowUp', () => {
+  it('delegates to updateFollowUp with cancelled status', async () => {
+    const row = makeRow({ status: 'cancelled', cancelled_at: '2026-05-02T10:00:00Z' })
+    const chain = makeMock(row)
+    chain.update = vi.fn().mockReturnThis()
+    chain.eq = vi.fn().mockReturnThis()
+    chain.select = vi.fn().mockReturnThis()
+    chain.single = vi.fn().mockResolvedValue({ data: row, error: null })
+    vi.spyOn(mockSupabaseClient, 'from').mockReturnValue(chain)
+
+    const result = await cancelFollowUp('fu-1')
+    expect(result.status).toBe('cancelled')
+  })
+})
+
+describe('deleteFollowUp', () => {
+  it('calls delete with correct id', async () => {
+    const chain = makeMock(null)
+    chain.delete = vi.fn().mockReturnThis()
+    chain.eq = vi.fn().mockResolvedValue({ error: null })
+    vi.spyOn(mockSupabaseClient, 'from').mockReturnValue(chain)
+
+    await deleteFollowUp('fu-1')
+    expect(chain.delete).toHaveBeenCalled()
+    expect(chain.eq).toHaveBeenCalledWith('id', 'fu-1')
+  })
+
+  it('throws on error', async () => {
+    const chain = makeMock(null)
+    chain.delete = vi.fn().mockReturnThis()
+    chain.eq = vi.fn().mockResolvedValue({ error: { message: 'delete failed' } })
+    vi.spyOn(mockSupabaseClient, 'from').mockReturnValue(chain)
+
+    await expect(deleteFollowUp('fu-1')).rejects.toThrow('delete failed')
+  })
+})
+
+describe('markFollowUpSurfaced', () => {
+  it('increments times_surfaced and sets last_surfaced_at', async () => {
+    const chain = makeMock(null)
+    chain.update = vi.fn().mockReturnThis()
+    chain.eq = vi.fn().mockResolvedValue({ error: null })
+    vi.spyOn(mockSupabaseClient, 'from').mockReturnValue(chain)
+
+    await markFollowUpSurfaced('fu-1', 2)
+
+    expect(chain.update).toHaveBeenCalledWith(expect.objectContaining({
+      times_surfaced: 3,
+      last_surfaced_at: expect.any(String),
+    }))
+    expect(chain.eq).toHaveBeenCalledWith('id', 'fu-1')
+  })
+})
+
+describe('markFollowUpsSurfaced', () => {
+  it('marks multiple follow-ups in parallel', async () => {
+    const chain = makeMock(null)
+    chain.update = vi.fn().mockReturnThis()
+    chain.eq = vi.fn().mockResolvedValue({ error: null })
+    vi.spyOn(mockSupabaseClient, 'from').mockReturnValue(chain)
+
+    await markFollowUpsSurfaced([
+      { id: 'fu-1', timesSurfaced: 0 },
+      { id: 'fu-2', timesSurfaced: 1 },
+    ])
+
+    expect(chain.update).toHaveBeenCalledTimes(2)
+  })
+})

--- a/lib/services/__tests__/weekly-review.test.ts
+++ b/lib/services/__tests__/weekly-review.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import '../../../test/mocks/supabase'
+import { mockSupabaseClient } from '../../../test/mocks/supabase'
+import {
+  getMondayOfWeek,
+  getSundayOfWeek,
+  formatWeekRange,
+  getOrCreateWeeklyReview,
+  getWeeklyReview,
+  updateReviewNotes,
+  completeWeeklyReview,
+  reopenWeeklyReview,
+  getDismissedItems,
+  dismissItem,
+} from '../weekly-review'
+
+describe('getMondayOfWeek', () => {
+  it('returns current Monday for a Wednesday', () => {
+    // 2026-04-29 is a Wednesday
+    const result = getMondayOfWeek(new Date('2026-04-29'))
+    expect(result).toBe('2026-04-27')
+  })
+
+  it('returns same day when called on Monday', () => {
+    const result = getMondayOfWeek(new Date('2026-04-27'))
+    expect(result).toBe('2026-04-27')
+  })
+
+  it('returns previous Monday when called on Sunday', () => {
+    const result = getMondayOfWeek(new Date('2026-05-03'))
+    expect(result).toBe('2026-04-27')
+  })
+
+  it('handles year boundary', () => {
+    const result = getMondayOfWeek(new Date('2026-01-01'))
+    expect(result).toBe('2025-12-29')
+  })
+})
+
+describe('getSundayOfWeek', () => {
+  it('returns Sunday 6 days after Monday', () => {
+    const result = getSundayOfWeek(new Date('2026-04-27'))
+    expect(result).toBe('2026-05-03')
+  })
+})
+
+describe('formatWeekRange', () => {
+  it('formats a week range correctly', () => {
+    const result = formatWeekRange('2026-04-27')
+    expect(result).toContain('27')
+    expect(result).toContain('Apr')
+    expect(result).toContain('3')
+    expect(result).toContain('May')
+  })
+
+  it('includes year in output', () => {
+    const result = formatWeekRange('2026-04-27')
+    expect(result).toContain('2026')
+  })
+})
+
+describe('Weekly Review Service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const mockReviewRow = {
+    id: 'review-1',
+    user_id: 'test-user-id',
+    week_start: '2026-04-27',
+    status: 'in_progress' as const,
+    completed_at: null,
+    notes: null,
+    snapshot: null,
+    created_at: '2026-04-27T09:00:00Z',
+    updated_at: '2026-04-27T09:00:00Z',
+  }
+
+  describe('getWeeklyReview', () => {
+    it('returns null when no review exists', async () => {
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        }),
+      })
+
+      const result = await getWeeklyReview('2026-04-27')
+      expect(result).toBeNull()
+    })
+
+    it('maps row to WeeklyReview correctly', async () => {
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: mockReviewRow, error: null }),
+            }),
+          }),
+        }),
+      })
+
+      const result = await getWeeklyReview('2026-04-27')
+      expect(result).not.toBeNull()
+      expect(result!.id).toBe('review-1')
+      expect(result!.weekStart).toBe('2026-04-27')
+      expect(result!.status).toBe('in_progress')
+      expect(result!.userId).toBe('test-user-id')
+    })
+  })
+
+  describe('getOrCreateWeeklyReview', () => {
+    it('returns existing review if found', async () => {
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: mockReviewRow, error: null }),
+            }),
+          }),
+        }),
+      })
+
+      const result = await getOrCreateWeeklyReview('2026-04-27')
+      expect(result.id).toBe('review-1')
+    })
+
+    it('creates new review when none exists', async () => {
+      const insertChain = {
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: mockReviewRow, error: null }),
+        }),
+      }
+      mockSupabaseClient.from = vi.fn()
+        .mockReturnValueOnce({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+              }),
+            }),
+          }),
+        })
+        .mockReturnValueOnce({
+          insert: vi.fn().mockReturnValue(insertChain),
+        })
+
+      const result = await getOrCreateWeeklyReview('2026-04-27')
+      expect(result.id).toBe('review-1')
+    })
+  })
+
+  describe('completeWeeklyReview', () => {
+    it('sets status to completed and saves snapshot', async () => {
+      const completedRow = { ...mockReviewRow, status: 'completed' as const, completed_at: '2026-04-29T10:00:00Z', snapshot: { totalSignals: 3 } }
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: completedRow, error: null }),
+            }),
+          }),
+        }),
+      })
+
+      const snapshot = {
+        overdueTasks: 1, noRecent1on1: 1, unresolvedActions: 1,
+        noEvidence: 0, upcomingDeadlines: 0, missingNotes: 0,
+        totalSignals: 3, criticalSignals: 1, warningSignals: 2,
+      }
+      const result = await completeWeeklyReview('review-1', snapshot)
+      expect(result.status).toBe('completed')
+    })
+  })
+
+  describe('reopenWeeklyReview', () => {
+    it('sets status back to in_progress', async () => {
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: mockReviewRow, error: null }),
+            }),
+          }),
+        }),
+      })
+
+      const result = await reopenWeeklyReview('review-1')
+      expect(result.status).toBe('in_progress')
+    })
+  })
+
+  describe('getDismissedItems', () => {
+    it('returns empty array when no items dismissed', async () => {
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+        }),
+      })
+
+      const result = await getDismissedItems('review-1')
+      expect(result).toEqual([])
+    })
+
+    it('maps dismissed rows correctly', async () => {
+      const mockRow = {
+        id: 'dismiss-1',
+        user_id: 'test-user-id',
+        weekly_review_id: 'review-1',
+        item_type: 'overdue_task',
+        reference_id: 'task-1',
+        reference_type: 'task',
+        dismissed_at: '2026-04-27T10:00:00Z',
+        note: 'handled',
+      }
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ data: [mockRow], error: null }),
+        }),
+      })
+
+      const result = await getDismissedItems('review-1')
+      expect(result).toHaveLength(1)
+      expect(result[0].itemType).toBe('overdue_task')
+      expect(result[0].referenceId).toBe('task-1')
+    })
+  })
+
+  describe('dismissItem', () => {
+    it('inserts dismissed item and returns mapped result', async () => {
+      const mockRow = {
+        id: 'dismiss-2',
+        user_id: 'test-user-id',
+        weekly_review_id: 'review-1',
+        item_type: 'no_recent_1on1',
+        reference_id: 'person-1',
+        reference_type: 'person',
+        dismissed_at: '2026-04-27T11:00:00Z',
+        note: 'on leave',
+      }
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: mockRow, error: null }),
+          }),
+        }),
+      })
+
+      const result = await dismissItem('review-1', 'no_recent_1on1', 'person-1', 'person', 'on leave')
+      expect(result.itemType).toBe('no_recent_1on1')
+      expect(result.note).toBe('on leave')
+    })
+  })
+
+  describe('updateReviewNotes', () => {
+    it('calls update with correct notes', async () => {
+      const updateFn = vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      })
+      mockSupabaseClient.from = vi.fn().mockReturnValue({ update: updateFn })
+
+      await updateReviewNotes('review-1', 'great week')
+      expect(updateFn).toHaveBeenCalledWith({ notes: 'great week' })
+    })
+  })
+})

--- a/lib/services/evidence.ts
+++ b/lib/services/evidence.ts
@@ -1,0 +1,374 @@
+import { createClient } from '@/lib/supabase/client'
+
+export type EvidenceCategory =
+  | 'achievement'
+  | 'feedback_given'
+  | 'feedback_received'
+  | 'concern'
+  | 'growth'
+  | 'delivery'
+  | 'behaviour'
+  | 'promotion_evidence'
+  | 'general'
+
+export type EvidenceSentiment = 'positive' | 'neutral' | 'negative'
+
+export interface EvidenceEntry {
+  id: string
+  personId: string
+  personName?: string | null
+  category: EvidenceCategory
+  title: string
+  content?: string | null
+  occurredAt: string
+  meetingId?: string | null
+  meetingTitle?: string | null
+  taskId?: string | null
+  taskTitle?: string | null
+  sentiment?: EvidenceSentiment | null
+  reviewPeriodStart?: string | null
+  reviewPeriodEnd?: string | null
+  includedInReview: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ReviewCycle {
+  id: string
+  name: string
+  startDate: string
+  endDate: string
+  status: 'active' | 'completed'
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ReviewSummary {
+  id: string
+  personId: string
+  reviewCycleId?: string | null
+  periodStart: string
+  periodEnd: string
+  summaryText?: string | null
+  managerNotes?: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+type EvidenceRow = {
+  id: string
+  owning_user_id: string
+  person_id: string
+  category: EvidenceCategory
+  title: string
+  content: string | null
+  occurred_at: string
+  meeting_id: string | null
+  task_id: string | null
+  sentiment: EvidenceSentiment | null
+  review_period_start: string | null
+  review_period_end: string | null
+  included_in_review: boolean
+  created_at: string
+  updated_at: string
+  person?: { full_name: string } | null
+  meeting?: { title: string } | null
+  task?: { title: string } | null
+}
+
+type ReviewCycleRow = {
+  id: string
+  owning_user_id: string
+  name: string
+  start_date: string
+  end_date: string
+  status: 'active' | 'completed'
+  created_at: string
+  updated_at: string
+}
+
+type ReviewSummaryRow = {
+  id: string
+  owning_user_id: string
+  person_id: string
+  review_cycle_id: string | null
+  period_start: string
+  period_end: string
+  summary_text: string | null
+  manager_notes: string | null
+  created_at: string
+  updated_at: string
+}
+
+function rowToEvidence(row: EvidenceRow): EvidenceEntry {
+  return {
+    id: row.id,
+    personId: row.person_id,
+    personName: row.person?.full_name ?? null,
+    category: row.category,
+    title: row.title,
+    content: row.content,
+    occurredAt: row.occurred_at,
+    meetingId: row.meeting_id,
+    meetingTitle: row.meeting?.title ?? null,
+    taskId: row.task_id,
+    taskTitle: row.task?.title ?? null,
+    sentiment: row.sentiment,
+    reviewPeriodStart: row.review_period_start,
+    reviewPeriodEnd: row.review_period_end,
+    includedInReview: row.included_in_review,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function rowToReviewCycle(row: ReviewCycleRow): ReviewCycle {
+  return {
+    id: row.id,
+    name: row.name,
+    startDate: row.start_date,
+    endDate: row.end_date,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function rowToReviewSummary(row: ReviewSummaryRow): ReviewSummary {
+  return {
+    id: row.id,
+    personId: row.person_id,
+    reviewCycleId: row.review_cycle_id,
+    periodStart: row.period_start,
+    periodEnd: row.period_end,
+    summaryText: row.summary_text,
+    managerNotes: row.manager_notes,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+const EVIDENCE_SELECT = `
+  *,
+  person:people(full_name),
+  meeting:meetings(title),
+  task:tasks(title)
+` as const
+
+// ── Evidence Entries ──────────────────────────────────────────────────────────
+
+export async function getEvidenceForPerson(personId: string): Promise<EvidenceEntry[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('evidence_entries')
+    .select(EVIDENCE_SELECT)
+    .eq('person_id', personId)
+    .order('occurred_at', { ascending: false })
+
+  if (error) throw new Error(error.message)
+  return (data as EvidenceRow[]).map(rowToEvidence)
+}
+
+export async function getEvidenceForPersonInPeriod(
+  personId: string,
+  periodStart: string,
+  periodEnd: string
+): Promise<EvidenceEntry[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('evidence_entries')
+    .select(EVIDENCE_SELECT)
+    .eq('person_id', personId)
+    .gte('occurred_at', periodStart)
+    .lte('occurred_at', periodEnd)
+    .order('occurred_at', { ascending: false })
+
+  if (error) throw new Error(error.message)
+  return (data as EvidenceRow[]).map(rowToEvidence)
+}
+
+export async function getAllEvidence(): Promise<EvidenceEntry[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('evidence_entries')
+    .select(EVIDENCE_SELECT)
+    .order('occurred_at', { ascending: false })
+
+  if (error) throw new Error(error.message)
+  return (data as EvidenceRow[]).map(rowToEvidence)
+}
+
+export async function createEvidence(
+  entry: Omit<EvidenceEntry, 'id' | 'createdAt' | 'updatedAt' | 'personName' | 'meetingTitle' | 'taskTitle'>
+): Promise<EvidenceEntry> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { data, error } = await supabase
+    .from('evidence_entries')
+    .insert({
+      owning_user_id: user.id,
+      person_id: entry.personId,
+      category: entry.category,
+      title: entry.title,
+      content: entry.content ?? null,
+      occurred_at: entry.occurredAt,
+      meeting_id: entry.meetingId ?? null,
+      task_id: entry.taskId ?? null,
+      sentiment: entry.sentiment ?? null,
+      review_period_start: entry.reviewPeriodStart ?? null,
+      review_period_end: entry.reviewPeriodEnd ?? null,
+      included_in_review: entry.includedInReview ?? true,
+    })
+    .select(EVIDENCE_SELECT)
+    .single()
+
+  if (error) throw new Error(error.message)
+  return rowToEvidence(data as EvidenceRow)
+}
+
+export async function updateEvidence(
+  id: string,
+  updates: Partial<Omit<EvidenceEntry, 'id' | 'createdAt' | 'updatedAt' | 'personName' | 'meetingTitle' | 'taskTitle'>>
+): Promise<EvidenceEntry> {
+  const supabase = createClient()
+
+  const dbUpdates: Record<string, unknown> = {}
+  if (updates.category !== undefined) dbUpdates.category = updates.category
+  if (updates.title !== undefined) dbUpdates.title = updates.title
+  if (updates.content !== undefined) dbUpdates.content = updates.content
+  if (updates.occurredAt !== undefined) dbUpdates.occurred_at = updates.occurredAt
+  if (updates.sentiment !== undefined) dbUpdates.sentiment = updates.sentiment
+  if (updates.includedInReview !== undefined) dbUpdates.included_in_review = updates.includedInReview
+  if (updates.meetingId !== undefined) dbUpdates.meeting_id = updates.meetingId
+  if (updates.taskId !== undefined) dbUpdates.task_id = updates.taskId
+  if (updates.reviewPeriodStart !== undefined) dbUpdates.review_period_start = updates.reviewPeriodStart
+  if (updates.reviewPeriodEnd !== undefined) dbUpdates.review_period_end = updates.reviewPeriodEnd
+
+  const { data, error } = await supabase
+    .from('evidence_entries')
+    .update(dbUpdates)
+    .eq('id', id)
+    .select(EVIDENCE_SELECT)
+    .single()
+
+  if (error) throw new Error(error.message)
+  return rowToEvidence(data as EvidenceRow)
+}
+
+export async function deleteEvidence(id: string): Promise<void> {
+  const supabase = createClient()
+  const { error } = await supabase.from('evidence_entries').delete().eq('id', id)
+  if (error) throw new Error(error.message)
+}
+
+// ── Review Cycles ─────────────────────────────────────────────────────────────
+
+export async function getReviewCycles(): Promise<ReviewCycle[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('review_cycles')
+    .select('*')
+    .order('start_date', { ascending: false })
+
+  if (error) throw new Error(error.message)
+  return (data as ReviewCycleRow[]).map(rowToReviewCycle)
+}
+
+export async function createReviewCycle(
+  cycle: Omit<ReviewCycle, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<ReviewCycle> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { data, error } = await supabase
+    .from('review_cycles')
+    .insert({
+      owning_user_id: user.id,
+      name: cycle.name,
+      start_date: cycle.startDate,
+      end_date: cycle.endDate,
+      status: cycle.status ?? 'active',
+    })
+    .select('*')
+    .single()
+
+  if (error) throw new Error(error.message)
+  return rowToReviewCycle(data as ReviewCycleRow)
+}
+
+export async function updateReviewCycle(
+  id: string,
+  updates: Partial<Omit<ReviewCycle, 'id' | 'createdAt' | 'updatedAt'>>
+): Promise<ReviewCycle> {
+  const supabase = createClient()
+
+  const dbUpdates: Record<string, unknown> = {}
+  if (updates.name !== undefined) dbUpdates.name = updates.name
+  if (updates.startDate !== undefined) dbUpdates.start_date = updates.startDate
+  if (updates.endDate !== undefined) dbUpdates.end_date = updates.endDate
+  if (updates.status !== undefined) dbUpdates.status = updates.status
+
+  const { data, error } = await supabase
+    .from('review_cycles')
+    .update(dbUpdates)
+    .eq('id', id)
+    .select('*')
+    .single()
+
+  if (error) throw new Error(error.message)
+  return rowToReviewCycle(data as ReviewCycleRow)
+}
+
+export async function deleteReviewCycle(id: string): Promise<void> {
+  const supabase = createClient()
+  const { error } = await supabase.from('review_cycles').delete().eq('id', id)
+  if (error) throw new Error(error.message)
+}
+
+// ── Review Summaries ──────────────────────────────────────────────────────────
+
+export async function getReviewSummary(
+  personId: string,
+  periodStart: string,
+  periodEnd: string
+): Promise<ReviewSummary | null> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('review_summaries')
+    .select('*')
+    .eq('person_id', personId)
+    .eq('period_start', periodStart)
+    .eq('period_end', periodEnd)
+    .maybeSingle()
+
+  if (error) throw new Error(error.message)
+  return data ? rowToReviewSummary(data as ReviewSummaryRow) : null
+}
+
+export async function upsertReviewSummary(
+  summary: Omit<ReviewSummary, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<ReviewSummary> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { data, error } = await supabase
+    .from('review_summaries')
+    .upsert({
+      owning_user_id: user.id,
+      person_id: summary.personId,
+      review_cycle_id: summary.reviewCycleId ?? null,
+      period_start: summary.periodStart,
+      period_end: summary.periodEnd,
+      summary_text: summary.summaryText ?? null,
+      manager_notes: summary.managerNotes ?? null,
+    }, { onConflict: 'owning_user_id,person_id,period_start,period_end' })
+    .select('*')
+    .single()
+
+  if (error) throw new Error(error.message)
+  return rowToReviewSummary(data as ReviewSummaryRow)
+}

--- a/lib/services/follow-ups.ts
+++ b/lib/services/follow-ups.ts
@@ -1,0 +1,190 @@
+import { createClient } from '@/lib/supabase/client'
+
+export type FollowUpStatus = 'open' | 'completed' | 'cancelled'
+export type FollowUpSourceType = 'meeting' | 'manual' | 'task'
+
+export interface FollowUp {
+  id: string
+  userId: string
+  personId: string
+  personName?: string | null
+  title: string
+  description: string | null
+  sourceType: FollowUpSourceType | null
+  sourceId: string | null
+  sourceName?: string | null
+  status: FollowUpStatus
+  dueDate: string | null
+  createdAt: string
+  completedAt: string | null
+  cancelledAt: string | null
+  lastSurfacedAt: string | null
+  timesSurfaced: number
+  updatedAt: string
+}
+
+type FollowUpRow = {
+  id: string
+  user_id: string
+  person_id: string
+  title: string
+  description: string | null
+  source_type: FollowUpSourceType | null
+  source_id: string | null
+  status: FollowUpStatus
+  due_date: string | null
+  created_at: string
+  completed_at: string | null
+  cancelled_at: string | null
+  last_surfaced_at: string | null
+  times_surfaced: number
+  updated_at: string
+  person?: { full_name: string } | null
+  meeting?: { title: string } | null
+}
+
+function rowToFollowUp(row: FollowUpRow): FollowUp {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    personId: row.person_id,
+    personName: row.person?.full_name ?? null,
+    title: row.title,
+    description: row.description,
+    sourceType: row.source_type,
+    sourceId: row.source_id,
+    sourceName: row.meeting?.title ?? null,
+    status: row.status,
+    dueDate: row.due_date,
+    createdAt: row.created_at,
+    completedAt: row.completed_at,
+    cancelledAt: row.cancelled_at,
+    lastSurfacedAt: row.last_surfaced_at,
+    timesSurfaced: row.times_surfaced,
+    updatedAt: row.updated_at,
+  }
+}
+
+const FOLLOW_UP_SELECT = `
+  *,
+  person:people(full_name),
+  meeting:meetings(title)
+` as const
+
+export async function getFollowUpsForPerson(personId: string): Promise<FollowUp[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('follow_ups')
+    .select(FOLLOW_UP_SELECT)
+    .eq('person_id', personId)
+    .order('status', { ascending: true })
+    .order('due_date', { ascending: true, nullsFirst: false })
+    .order('created_at', { ascending: false })
+  if (error) throw new Error(error.message)
+  return (data as FollowUpRow[]).map(rowToFollowUp)
+}
+
+export async function getAllFollowUps(): Promise<FollowUp[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('follow_ups')
+    .select(FOLLOW_UP_SELECT)
+    .order('status', { ascending: true })
+    .order('due_date', { ascending: true, nullsFirst: false })
+    .order('created_at', { ascending: false })
+  if (error) throw new Error(error.message)
+  return (data as FollowUpRow[]).map(rowToFollowUp)
+}
+
+export async function getOpenFollowUps(): Promise<FollowUp[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('follow_ups')
+    .select(FOLLOW_UP_SELECT)
+    .eq('status', 'open')
+    .order('due_date', { ascending: true, nullsFirst: false })
+    .order('created_at', { ascending: true })
+  if (error) throw new Error(error.message)
+  return (data as FollowUpRow[]).map(rowToFollowUp)
+}
+
+export async function createFollowUp(
+  input: Omit<FollowUp, 'id' | 'userId' | 'personName' | 'sourceName' | 'createdAt' | 'completedAt' | 'cancelledAt' | 'lastSurfacedAt' | 'timesSurfaced' | 'updatedAt'>
+): Promise<FollowUp> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { data, error } = await supabase
+    .from('follow_ups')
+    .insert({
+      user_id: user.id,
+      person_id: input.personId,
+      title: input.title,
+      description: input.description ?? null,
+      source_type: input.sourceType ?? null,
+      source_id: input.sourceId ?? null,
+      status: input.status ?? 'open',
+      due_date: input.dueDate ?? null,
+    })
+    .select(FOLLOW_UP_SELECT)
+    .single()
+  if (error) throw new Error(error.message)
+  return rowToFollowUp(data as FollowUpRow)
+}
+
+export async function updateFollowUp(
+  id: string,
+  updates: Partial<Pick<FollowUp, 'title' | 'description' | 'dueDate' | 'status'>>
+): Promise<FollowUp> {
+  const supabase = createClient()
+  const dbUpdates: Record<string, unknown> = {}
+  if (updates.title !== undefined) dbUpdates.title = updates.title
+  if (updates.description !== undefined) dbUpdates.description = updates.description
+  if (updates.dueDate !== undefined) dbUpdates.due_date = updates.dueDate
+  if (updates.status !== undefined) {
+    dbUpdates.status = updates.status
+    if (updates.status === 'completed') dbUpdates.completed_at = new Date().toISOString()
+    if (updates.status === 'cancelled') dbUpdates.cancelled_at = new Date().toISOString()
+  }
+  const { data, error } = await supabase
+    .from('follow_ups')
+    .update(dbUpdates)
+    .eq('id', id)
+    .select(FOLLOW_UP_SELECT)
+    .single()
+  if (error) throw new Error(error.message)
+  return rowToFollowUp(data as FollowUpRow)
+}
+
+export async function completeFollowUp(id: string): Promise<FollowUp> {
+  return updateFollowUp(id, { status: 'completed' })
+}
+
+export async function cancelFollowUp(id: string): Promise<FollowUp> {
+  return updateFollowUp(id, { status: 'cancelled' })
+}
+
+export async function deleteFollowUp(id: string): Promise<void> {
+  const supabase = createClient()
+  const { error } = await supabase.from('follow_ups').delete().eq('id', id)
+  if (error) throw new Error(error.message)
+}
+
+/** Mark a follow-up as surfaced — increments counter, updates last_surfaced_at */
+export async function markFollowUpSurfaced(id: string, currentCount: number): Promise<void> {
+  const supabase = createClient()
+  const { error } = await supabase
+    .from('follow_ups')
+    .update({
+      last_surfaced_at: new Date().toISOString(),
+      times_surfaced: currentCount + 1,
+    })
+    .eq('id', id)
+  if (error) throw new Error(error.message)
+}
+
+/** Bulk mark multiple follow-ups as surfaced */
+export async function markFollowUpsSurfaced(followUps: Pick<FollowUp, 'id' | 'timesSurfaced'>[]): Promise<void> {
+  await Promise.all(followUps.map(f => markFollowUpSurfaced(f.id, f.timesSurfaced)))
+}

--- a/lib/services/weekly-review.ts
+++ b/lib/services/weekly-review.ts
@@ -10,6 +10,10 @@ export type DismissedItemType =
   | 'upcoming_deadline'
   | 'stale_goal'
   | 'missing_notes'
+  | 'overdue_follow_up'
+  | 'ageing_follow_up'
+  | 'surfaced_follow_up'
+  | 'action_overload'
 
 export interface WeeklyReview {
   id: string

--- a/lib/services/weekly-review.ts
+++ b/lib/services/weekly-review.ts
@@ -1,0 +1,269 @@
+import { createClient } from '@/lib/supabase/client'
+
+export type WeeklyReviewStatus = 'in_progress' | 'completed'
+
+export type DismissedItemType =
+  | 'overdue_task'
+  | 'no_recent_1on1'
+  | 'unresolved_action'
+  | 'no_evidence'
+  | 'upcoming_deadline'
+  | 'stale_goal'
+  | 'missing_notes'
+
+export interface WeeklyReview {
+  id: string
+  userId: string
+  weekStart: string
+  status: WeeklyReviewStatus
+  completedAt: string | null
+  notes: string | null
+  snapshot: ReviewSnapshot | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ReviewSnapshot {
+  overdueTasks: number
+  noRecent1on1: number
+  unresolvedActions: number
+  noEvidence: number
+  upcomingDeadlines: number
+  missingNotes: number
+  totalSignals: number
+  criticalSignals: number
+  warningSignals: number
+}
+
+export interface DismissedItem {
+  id: string
+  userId: string
+  weeklyReviewId: string
+  itemType: DismissedItemType
+  referenceId: string | null
+  referenceType: string | null
+  dismissedAt: string
+  note: string | null
+}
+
+type WeeklyReviewRow = {
+  id: string
+  user_id: string
+  week_start: string
+  status: WeeklyReviewStatus
+  completed_at: string | null
+  notes: string | null
+  snapshot: ReviewSnapshot | null
+  created_at: string
+  updated_at: string
+}
+
+type DismissedItemRow = {
+  id: string
+  user_id: string
+  weekly_review_id: string
+  item_type: DismissedItemType
+  reference_id: string | null
+  reference_type: string | null
+  dismissed_at: string
+  note: string | null
+}
+
+function rowToReview(row: WeeklyReviewRow): WeeklyReview {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    weekStart: row.week_start,
+    status: row.status,
+    completedAt: row.completed_at,
+    notes: row.notes,
+    snapshot: row.snapshot,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function rowToDismissed(row: DismissedItemRow): DismissedItem {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    weeklyReviewId: row.weekly_review_id,
+    itemType: row.item_type,
+    referenceId: row.reference_id,
+    referenceType: row.reference_type,
+    dismissedAt: row.dismissed_at,
+    note: row.note,
+  }
+}
+
+/** Returns the Monday (ISO date string) of the week containing the given date */
+export function getMondayOfWeek(date: Date = new Date()): string {
+  const d = new Date(date)
+  const day = d.getDay()
+  const diff = day === 0 ? -6 : 1 - day
+  d.setDate(d.getDate() + diff)
+  return d.toISOString().split('T')[0]
+}
+
+/** Returns the Sunday (ISO date string) of the week containing the given date */
+export function getSundayOfWeek(date: Date = new Date()): string {
+  const monday = new Date(getMondayOfWeek(date))
+  const sunday = new Date(monday)
+  sunday.setDate(monday.getDate() + 6)
+  return sunday.toISOString().split('T')[0]
+}
+
+/** Formats a week range as "28 Apr – 2 May 2026" */
+export function formatWeekRange(weekStart: string): string {
+  const monday = new Date(weekStart + 'T00:00:00')
+  const sunday = new Date(monday)
+  sunday.setDate(monday.getDate() + 6)
+  const fmt = (d: Date, showYear: boolean) =>
+    d.toLocaleDateString('en-GB', {
+      day: 'numeric',
+      month: 'short',
+      ...(showYear ? { year: 'numeric' } : {}),
+    })
+  const sameYear = monday.getFullYear() === sunday.getFullYear()
+  return `${fmt(monday, false)} – ${fmt(sunday, sameYear)}`
+}
+
+/** Get or create the weekly review row for the given week */
+export async function getOrCreateWeeklyReview(weekStart: string): Promise<WeeklyReview> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { data: existing } = await supabase
+    .from('weekly_reviews')
+    .select('*')
+    .eq('user_id', user.id)
+    .eq('week_start', weekStart)
+    .maybeSingle()
+
+  if (existing) return rowToReview(existing as WeeklyReviewRow)
+
+  const { data, error } = await supabase
+    .from('weekly_reviews')
+    .insert({ user_id: user.id, week_start: weekStart, status: 'in_progress' })
+    .select('*')
+    .single()
+
+  if (error) throw new Error(error.message)
+  return rowToReview(data as WeeklyReviewRow)
+}
+
+/** Get a weekly review for a specific week (returns null if none exists) */
+export async function getWeeklyReview(weekStart: string): Promise<WeeklyReview | null> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { data } = await supabase
+    .from('weekly_reviews')
+    .select('*')
+    .eq('user_id', user.id)
+    .eq('week_start', weekStart)
+    .maybeSingle()
+
+  return data ? rowToReview(data as WeeklyReviewRow) : null
+}
+
+/** Update review notes (auto-saves reflection) */
+export async function updateReviewNotes(id: string, notes: string): Promise<void> {
+  const supabase = createClient()
+  const { error } = await supabase
+    .from('weekly_reviews')
+    .update({ notes })
+    .eq('id', id)
+  if (error) throw new Error(error.message)
+}
+
+/** Complete a weekly review — saves snapshot and sets status */
+export async function completeWeeklyReview(id: string, snapshot: ReviewSnapshot): Promise<WeeklyReview> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('weekly_reviews')
+    .update({
+      status: 'completed',
+      completed_at: new Date().toISOString(),
+      snapshot,
+    })
+    .eq('id', id)
+    .select('*')
+    .single()
+  if (error) throw new Error(error.message)
+  return rowToReview(data as WeeklyReviewRow)
+}
+
+/** Reopen a completed weekly review */
+export async function reopenWeeklyReview(id: string): Promise<WeeklyReview> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('weekly_reviews')
+    .update({ status: 'in_progress', completed_at: null })
+    .eq('id', id)
+    .select('*')
+    .single()
+  if (error) throw new Error(error.message)
+  return rowToReview(data as WeeklyReviewRow)
+}
+
+/** Get dismissed items for a weekly review */
+export async function getDismissedItems(weeklyReviewId: string): Promise<DismissedItem[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('review_dismissed_items')
+    .select('*')
+    .eq('weekly_review_id', weeklyReviewId)
+  if (error) throw new Error(error.message)
+  return (data as DismissedItemRow[]).map(rowToDismissed)
+}
+
+/** Dismiss a signal item for this week */
+export async function dismissItem(
+  weeklyReviewId: string,
+  itemType: DismissedItemType,
+  referenceId: string | null,
+  referenceType: string | null,
+  note?: string
+): Promise<DismissedItem> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { data, error } = await supabase
+    .from('review_dismissed_items')
+    .insert({
+      user_id: user.id,
+      weekly_review_id: weeklyReviewId,
+      item_type: itemType,
+      reference_id: referenceId,
+      reference_type: referenceType,
+      note: note ?? null,
+    })
+    .select('*')
+    .single()
+  if (error) throw new Error(error.message)
+  return rowToDismissed(data as DismissedItemRow)
+}
+
+/** Remove a dismissed item (un-dismiss) */
+export async function undismissItem(dismissedItemId: string): Promise<void> {
+  const supabase = createClient()
+  const { error } = await supabase
+    .from('review_dismissed_items')
+    .delete()
+    .eq('id', dismissedItemId)
+  if (error) throw new Error(error.message)
+}
+
+/** Get the most recent weekly review to check sidebar indicator state */
+export async function getCurrentWeekReviewStatus(): Promise<{
+  status: WeeklyReviewStatus | null
+  weekStart: string
+}> {
+  const weekStart = getMondayOfWeek()
+  const review = await getWeeklyReview(weekStart)
+  return { status: review?.status ?? null, weekStart }
+}

--- a/lib/signals/__tests__/signals.test.ts
+++ b/lib/signals/__tests__/signals.test.ts
@@ -55,7 +55,6 @@ describe('computeAttentionScore', () => {
 
   it('surfaced_follow_up is highest weight signal', () => {
     const surfaced = makeSignal('surfaced_follow_up', 'critical')
-    const overdue = makeSignal('overdue_follow_up', 'critical')
     const scoreSurfaced = SIGNAL_WEIGHTS['surfaced_follow_up'] + CRITICAL_BONUS
     const scoreOverdue = SIGNAL_WEIGHTS['overdue_follow_up'] + CRITICAL_BONUS
     expect(scoreSurfaced).toBeGreaterThan(scoreOverdue)

--- a/lib/signals/__tests__/signals.test.ts
+++ b/lib/signals/__tests__/signals.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeAttentionScore,
+  scoreToColor,
+  scoreToBg,
+  SIGNAL_WEIGHTS,
+  CRITICAL_BONUS,
+  type Signal,
+  type SignalType,
+} from '../types'
+
+function makeSignal(type: SignalType, severity: Signal['severity'] = 'warning'): Signal {
+  return {
+    type,
+    severity,
+    message: `test signal: ${type}`,
+    entityId: 'e-1',
+    entityType: 'person',
+  }
+}
+
+describe('computeAttentionScore', () => {
+  it('returns 0 for empty signals', () => {
+    expect(computeAttentionScore([])).toBe(0)
+  })
+
+  it('sums base weights for info/warning signals', () => {
+    const signals: Signal[] = [
+      makeSignal('no_recent_1on1', 'warning'),  // weight 3
+      makeSignal('no_evidence', 'warning'),      // weight 2
+    ]
+    expect(computeAttentionScore(signals)).toBe(5)
+  })
+
+  it('adds CRITICAL_BONUS for critical signals', () => {
+    const signals: Signal[] = [
+      makeSignal('overdue_task', 'critical'),    // 3 + 2 = 5
+    ]
+    expect(computeAttentionScore(signals)).toBe(3 + CRITICAL_BONUS)
+  })
+
+  it('does not add bonus for warning severity', () => {
+    const signals: Signal[] = [
+      makeSignal('overdue_task', 'warning'),     // 3 only
+    ]
+    expect(computeAttentionScore(signals)).toBe(3)
+  })
+
+  it('upcoming_deadline has zero base weight', () => {
+    const signals: Signal[] = [
+      makeSignal('upcoming_deadline', 'info'),
+    ]
+    expect(computeAttentionScore(signals)).toBe(0)
+  })
+
+  it('surfaced_follow_up is highest weight signal', () => {
+    const surfaced = makeSignal('surfaced_follow_up', 'critical')
+    const overdue = makeSignal('overdue_follow_up', 'critical')
+    const scoreSurfaced = SIGNAL_WEIGHTS['surfaced_follow_up'] + CRITICAL_BONUS
+    const scoreOverdue = SIGNAL_WEIGHTS['overdue_follow_up'] + CRITICAL_BONUS
+    expect(scoreSurfaced).toBeGreaterThan(scoreOverdue)
+    expect(computeAttentionScore([surfaced])).toBe(scoreSurfaced)
+  })
+
+  it('accumulates across multiple signals', () => {
+    const signals: Signal[] = [
+      makeSignal('overdue_follow_up', 'critical'),  // 4 + 2 = 6
+      makeSignal('no_recent_1on1', 'warning'),       // 3
+      makeSignal('missing_notes', 'info'),            // 2
+    ]
+    expect(computeAttentionScore(signals)).toBe(11)
+  })
+})
+
+describe('scoreToColor', () => {
+  it('returns green for score 0', () => {
+    expect(scoreToColor(0)).toBe('#00f058')
+  })
+
+  it('returns yellow for low scores (1-5)', () => {
+    expect(scoreToColor(1)).toBe('#ffd43b')
+    expect(scoreToColor(5)).toBe('#ffd43b')
+  })
+
+  it('returns orange for medium scores (6-10)', () => {
+    expect(scoreToColor(6)).toBe('#ffa94d')
+    expect(scoreToColor(10)).toBe('#ffa94d')
+  })
+
+  it('returns red for high scores (11+)', () => {
+    expect(scoreToColor(11)).toBe('#ff6b6b')
+    expect(scoreToColor(100)).toBe('#ff6b6b')
+  })
+})
+
+describe('scoreToBg', () => {
+  it('returns dark green bg for score 0', () => {
+    expect(scoreToBg(0)).toBe('#0d1f14')
+  })
+
+  it('returns dark yellow bg for low scores', () => {
+    expect(scoreToBg(3)).toBe('#2a2508')
+  })
+
+  it('returns dark orange bg for medium scores', () => {
+    expect(scoreToBg(8)).toBe('#2a1a08')
+  })
+
+  it('returns dark red bg for high scores', () => {
+    expect(scoreToBg(15)).toBe('#2a0a0a')
+  })
+})
+
+describe('SIGNAL_WEIGHTS completeness', () => {
+  const expectedTypes: SignalType[] = [
+    'overdue_task', 'no_recent_1on1', 'unresolved_action', 'no_evidence',
+    'upcoming_deadline', 'missing_notes', 'overdue_follow_up',
+    'ageing_follow_up', 'surfaced_follow_up', 'action_overload',
+  ]
+
+  it('has a weight entry for every signal type', () => {
+    for (const type of expectedTypes) {
+      expect(SIGNAL_WEIGHTS).toHaveProperty(type)
+      expect(typeof SIGNAL_WEIGHTS[type]).toBe('number')
+    }
+  })
+
+  it('overdue signals weight more than info signals', () => {
+    expect(SIGNAL_WEIGHTS['overdue_follow_up']).toBeGreaterThan(SIGNAL_WEIGHTS['upcoming_deadline'])
+    expect(SIGNAL_WEIGHTS['surfaced_follow_up']).toBeGreaterThan(SIGNAL_WEIGHTS['no_evidence'])
+  })
+})

--- a/lib/signals/compute.ts
+++ b/lib/signals/compute.ts
@@ -1,6 +1,5 @@
 import { createClient } from '@/lib/supabase/client'
 import type { Signal, SignalSeverity } from './types'
-import type { FollowUp } from '@/lib/services/follow-ups'
 
 const DAYS_MS = 24 * 60 * 60 * 1000
 
@@ -176,7 +175,6 @@ export function computePeopleSignals(
   today: Date
 ): Signal[] {
   const signals: Signal[] = []
-  const todayISO = todayStr()
 
   // Build lookup maps
   const oneOnOneMeetingsByPerson: Record<string, string> = {}

--- a/lib/signals/compute.ts
+++ b/lib/signals/compute.ts
@@ -1,0 +1,415 @@
+import { createClient } from '@/lib/supabase/client'
+import type { Signal, SignalSeverity } from './types'
+import type { FollowUp } from '@/lib/services/follow-ups'
+
+const DAYS_MS = 24 * 60 * 60 * 1000
+
+export function daysBetween(a: Date, b: Date): number {
+  return Math.floor((b.getTime() - a.getTime()) / DAYS_MS)
+}
+
+export function todayStr(): string {
+  return new Date().toISOString().split('T')[0]
+}
+
+export function endOfWeekStr(): string {
+  const today = new Date()
+  const day = today.getDay()
+  const daysUntilSunday = day === 0 ? 0 : 7 - day
+  const sunday = new Date(today)
+  sunday.setDate(today.getDate() + daysUntilSunday)
+  return sunday.toISOString().split('T')[0]
+}
+
+export function nDaysAgoStr(n: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() - n)
+  return d.toISOString().split('T')[0]
+}
+
+export function parseActionItemsFromHtml(html: string | null): string[] {
+  if (!html) return []
+  const matches = [...html.matchAll(/<li[^>]*>([\s\S]*?)<\/li>/gi)]
+  return matches.map(m => m[1].replace(/<[^>]+>/g, '').trim()).filter(Boolean)
+}
+
+type DismissKey = string // `${type}::${referenceId}`
+
+export function buildDismissedSet(dismissed: { itemType: string; referenceId: string | null }[]): Set<DismissKey> {
+  return new Set(dismissed.map(d => `${d.itemType}::${d.referenceId ?? ''}`))
+}
+
+export function isDismissed(set: Set<DismissKey>, type: string, refId: string): boolean {
+  return set.has(`${type}::${refId}`)
+}
+
+/**
+ * Load all raw data needed for signal computation in one pass.
+ * Returns parallel query results for reuse across multiple signal types.
+ */
+export async function loadSignalData() {
+  const supabase = createClient()
+  const todayISO = todayStr()
+  const endOfWeekISO = endOfWeekStr()
+
+  const [
+    { data: overdueTasks },
+    { data: activePeople },
+    { data: recentMeetings },
+    { data: upcomingTasks },
+    { data: evidenceRecent },
+    { data: meetingsWithNotes },
+    { data: openFollowUps },
+    { data: tasksByPerson },
+  ] = await Promise.all([
+    supabase
+      .from('tasks')
+      .select('id, title, due_date, priority')
+      .lt('due_date', todayISO)
+      .not('status', 'eq', 'completed')
+      .not('due_date', 'is', null),
+
+    supabase
+      .from('people')
+      .select('id, full_name, role')
+      .eq('status', 'active'),
+
+    supabase
+      .from('meetings')
+      .select('id, title, meeting_type, meeting_date, person_id, action_items, notes')
+      .gte('meeting_date', nDaysAgoStr(30))
+      .order('meeting_date', { ascending: false }),
+
+    supabase
+      .from('tasks')
+      .select('id, title, due_date, priority')
+      .gte('due_date', todayISO)
+      .lte('due_date', endOfWeekISO)
+      .not('status', 'eq', 'completed'),
+
+    supabase
+      .from('evidence_entries')
+      .select('person_id, occurred_at')
+      .gte('occurred_at', nDaysAgoStr(90)),
+
+    supabase
+      .from('meetings')
+      .select('id, person_id, meeting_date, notes')
+      .gte('meeting_date', nDaysAgoStr(21))
+      .not('notes', 'is', null),
+
+    supabase
+      .from('follow_ups')
+      .select('id, person_id, title, status, due_date, created_at, times_surfaced')
+      .eq('status', 'open'),
+
+    // Tasks linked to people via task_relations
+    supabase
+      .from('task_relations')
+      .select('entity_id, task_id')
+      .eq('entity_type', 'person')
+      .in('task_id',
+        (await supabase.from('tasks').select('id').not('status', 'eq', 'completed')).data?.map((t: any) => t.id) ?? []
+      ),
+  ])
+
+  return {
+    overdueTasks: overdueTasks ?? [],
+    activePeople: activePeople ?? [],
+    recentMeetings: recentMeetings ?? [],
+    upcomingTasks: upcomingTasks ?? [],
+    evidenceRecent: evidenceRecent ?? [],
+    meetingsWithNotes: meetingsWithNotes ?? [],
+    openFollowUps: openFollowUps ?? [],
+    tasksByPerson: tasksByPerson ?? [],
+  }
+}
+
+export type SignalData = Awaited<ReturnType<typeof loadSignalData>>
+
+/**
+ * Compute task-level signals (overdue + upcoming) from preloaded data.
+ * Used by Weekly Review.
+ */
+export function computeTaskSignals(
+  data: Pick<SignalData, 'overdueTasks' | 'upcomingTasks'>,
+  dismissedSet: Set<DismissKey>,
+  today: Date
+): Signal[] {
+  const signals: Signal[] = []
+
+  for (const task of data.overdueTasks) {
+    if (isDismissed(dismissedSet, 'overdue_task', task.id)) continue
+    const daysOverdue = daysBetween(new Date(task.due_date + 'T00:00:00'), today)
+    signals.push({
+      type: 'overdue_task',
+      severity: daysOverdue >= 4 ? 'critical' : 'warning',
+      message: `"${task.title}" is ${daysOverdue} day${daysOverdue === 1 ? '' : 's'} overdue`,
+      entityId: task.id,
+      entityType: 'task',
+      meta: { daysOverdue, dueDate: task.due_date, priority: task.priority },
+    })
+  }
+
+  for (const task of data.upcomingTasks) {
+    if (isDismissed(dismissedSet, 'upcoming_deadline', task.id)) continue
+    signals.push({
+      type: 'upcoming_deadline',
+      severity: 'info',
+      message: `"${task.title}" due on ${new Date(task.due_date + 'T00:00:00').toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })}`,
+      entityId: task.id,
+      entityType: 'task',
+      meta: { dueDate: task.due_date, priority: task.priority },
+    })
+  }
+
+  return signals
+}
+
+/**
+ * Compute all person-centric signals for all active people.
+ * Used by both Radar (all people) and Weekly Review (people section).
+ */
+export function computePeopleSignals(
+  data: SignalData,
+  dismissedSet: Set<DismissKey>,
+  today: Date
+): Signal[] {
+  const signals: Signal[] = []
+  const todayISO = todayStr()
+
+  // Build lookup maps
+  const oneOnOneMeetingsByPerson: Record<string, string> = {}
+  for (const m of data.recentMeetings) {
+    if (m.meeting_type === '1:1' && m.person_id) {
+      if (!oneOnOneMeetingsByPerson[m.person_id]) {
+        oneOnOneMeetingsByPerson[m.person_id] = m.meeting_date
+      }
+    }
+  }
+
+  const notesDateByPerson: Record<string, string> = {}
+  for (const m of data.meetingsWithNotes) {
+    if (m.person_id && m.notes) {
+      if (!notesDateByPerson[m.person_id] || m.meeting_date > notesDateByPerson[m.person_id]) {
+        notesDateByPerson[m.person_id] = m.meeting_date
+      }
+    }
+  }
+
+  const evidence90DaysPersonIds = new Set(data.evidenceRecent.map((e: any) => e.person_id))
+  const evidenceAnyPersonIds = new Set(data.evidenceRecent.map((e: any) => e.person_id))
+
+  const openTasksByPerson: Record<string, number> = {}
+  for (const rel of data.tasksByPerson) {
+    if (!openTasksByPerson[rel.entity_id]) openTasksByPerson[rel.entity_id] = 0
+    openTasksByPerson[rel.entity_id]++
+  }
+
+  for (const person of data.activePeople) {
+    const lastOneOnOne = oneOnOneMeetingsByPerson[person.id]
+    const lastNoteDate = notesDateByPerson[person.id]
+
+    // Signal: no recent 1:1
+    if (!isDismissed(dismissedSet, 'no_recent_1on1', person.id)) {
+      if (!lastOneOnOne) {
+        signals.push({
+          type: 'no_recent_1on1',
+          severity: 'critical',
+          message: `No 1:1 with ${person.full_name} in the last 30 days`,
+          personId: person.id,
+          personName: person.full_name,
+          entityId: person.id,
+          entityType: 'person',
+          meta: { daysSince: null },
+        })
+      } else {
+        const daysSince = daysBetween(new Date(lastOneOnOne + 'T00:00:00'), today)
+        if (daysSince >= 14) {
+          signals.push({
+            type: 'no_recent_1on1',
+            severity: daysSince >= 21 ? 'critical' : 'warning',
+            message: `No 1:1 with ${person.full_name} in ${daysSince} days`,
+            personId: person.id,
+            personName: person.full_name,
+            entityId: person.id,
+            entityType: 'person',
+            meta: { daysSince, lastDate: lastOneOnOne },
+          })
+        }
+      }
+    }
+
+    // Signal: no recent evidence
+    if (!isDismissed(dismissedSet, 'no_evidence', person.id)) {
+      if (!evidence90DaysPersonIds.has(person.id)) {
+        signals.push({
+          type: 'no_evidence',
+          severity: evidenceAnyPersonIds.has(person.id) ? 'warning' : 'info',
+          message: `No evidence logged for ${person.full_name} in 90 days`,
+          personId: person.id,
+          personName: person.full_name,
+          entityId: person.id,
+          entityType: 'person',
+        })
+      }
+    }
+
+    // Signal: no recent meeting notes
+    if (!isDismissed(dismissedSet, 'missing_notes', person.id)) {
+      if (!lastNoteDate) {
+        signals.push({
+          type: 'missing_notes',
+          severity: 'info',
+          message: `No meeting notes involving ${person.full_name} in 21 days`,
+          personId: person.id,
+          personName: person.full_name,
+          entityId: person.id,
+          entityType: 'person',
+          meta: { daysSince: null },
+        })
+      }
+    }
+
+    // Signal: action overload
+    const openTaskCount = openTasksByPerson[person.id] ?? 0
+    if (openTaskCount >= 5 && !isDismissed(dismissedSet, 'action_overload', person.id)) {
+      signals.push({
+        type: 'action_overload',
+        severity: openTaskCount >= 10 ? 'critical' : 'warning',
+        message: `${person.full_name} has ${openTaskCount} open tasks`,
+        personId: person.id,
+        personName: person.full_name,
+        entityId: person.id,
+        entityType: 'person',
+        meta: { openTaskCount },
+      })
+    }
+  }
+
+  return signals
+}
+
+/**
+ * Compute follow-up signals from preloaded open follow-ups.
+ */
+export function computeFollowUpSignals(
+  openFollowUps: any[],
+  dismissedSet: Set<DismissKey>,
+  today: Date
+): Signal[] {
+  const signals: Signal[] = []
+
+  for (const fu of openFollowUps) {
+    const ageInDays = daysBetween(new Date(fu.created_at), today)
+
+    // Surfaced 3+ times without resolution → critical
+    if (fu.times_surfaced >= 3 && !isDismissed(dismissedSet, 'surfaced_follow_up', fu.id)) {
+      signals.push({
+        type: 'surfaced_follow_up',
+        severity: 'critical',
+        message: `"${fu.title}" has been flagged ${fu.times_surfaced} times without resolution`,
+        personId: fu.person_id,
+        entityId: fu.id,
+        entityType: 'follow_up',
+        meta: { personId: fu.person_id, timesSurfaced: fu.times_surfaced },
+      })
+      continue
+    }
+
+    // Overdue (due_date passed)
+    if (fu.due_date && fu.due_date < todayStr()) {
+      if (!isDismissed(dismissedSet, 'overdue_follow_up', fu.id)) {
+        const daysOverdue = daysBetween(new Date(fu.due_date + 'T00:00:00'), today)
+        signals.push({
+          type: 'overdue_follow_up',
+          severity: 'warning',
+          message: `Follow-up "${fu.title}" is ${daysOverdue} day${daysOverdue === 1 ? '' : 's'} overdue`,
+          personId: fu.person_id,
+          entityId: fu.id,
+          entityType: 'follow_up',
+          meta: { personId: fu.person_id, daysOverdue, dueDate: fu.due_date },
+        })
+      }
+      continue
+    }
+
+    // Ageing (open 14+ days with no due date, or 30+ days regardless)
+    if (!isDismissed(dismissedSet, 'ageing_follow_up', fu.id)) {
+      if (ageInDays >= 30) {
+        signals.push({
+          type: 'ageing_follow_up',
+          severity: 'critical',
+          message: `Follow-up "${fu.title}" has been open for ${ageInDays} days`,
+          personId: fu.person_id,
+          entityId: fu.id,
+          entityType: 'follow_up',
+          meta: { personId: fu.person_id, ageInDays },
+        })
+      } else if (ageInDays >= 14 && !fu.due_date) {
+        signals.push({
+          type: 'ageing_follow_up',
+          severity: 'warning',
+          message: `Follow-up "${fu.title}" has been open for ${ageInDays} days`,
+          personId: fu.person_id,
+          entityId: fu.id,
+          entityType: 'follow_up',
+          meta: { personId: fu.person_id, ageInDays },
+        })
+      }
+    }
+  }
+
+  return signals
+}
+
+/**
+ * Compute unresolved meeting action signals from recent meetings.
+ */
+export async function computeActionItemSignals(
+  recentMeetings: any[],
+  dismissedSet: Set<DismissKey>,
+  today: Date
+): Promise<Signal[]> {
+  const supabase = createClient()
+  const signals: Signal[] = []
+
+  for (const meeting of recentMeetings) {
+    const items = parseActionItemsFromHtml(meeting.action_items)
+    if (items.length === 0) continue
+
+    const { data: linkedTasks } = await supabase
+      .from('task_relations')
+      .select('task_id, tasks!inner(id, title, status, created_at)')
+      .eq('entity_type', 'meeting')
+      .eq('entity_id', meeting.id)
+
+    if (!linkedTasks || linkedTasks.length === 0) continue
+
+    const meetingDate = new Date(meeting.meeting_date + 'T00:00:00')
+    const daysAgo = daysBetween(meetingDate, today)
+
+    for (const rel of linkedTasks) {
+      const task = (rel as any).tasks
+      if (!task || task.status === 'completed') continue
+      if (isDismissed(dismissedSet, 'unresolved_action', task.id)) continue
+      const severity: SignalSeverity = daysAgo >= 14 ? 'critical' : daysAgo >= 7 ? 'warning' : 'info'
+      signals.push({
+        type: 'unresolved_action',
+        severity,
+        message: `"${task.title}" from "${meeting.title}" (${daysAgo} days ago) is still open`,
+        entityId: meeting.id,
+        entityType: 'meeting',
+        meta: { taskId: task.id, taskTitle: task.title, meetingTitle: meeting.title, daysAgo },
+      })
+    }
+  }
+
+  return signals
+}
+
+/** Sort signals: critical first, warning second, info last */
+export function sortSignals(signals: Signal[]): Signal[] {
+  const order: Record<string, number> = { critical: 0, warning: 1, info: 2 }
+  return [...signals].sort((a, b) => order[a.severity] - order[b.severity])
+}

--- a/lib/signals/types.ts
+++ b/lib/signals/types.ts
@@ -1,0 +1,63 @@
+export type SignalSeverity = 'info' | 'warning' | 'critical'
+
+export type SignalType =
+  | 'overdue_task'
+  | 'no_recent_1on1'
+  | 'unresolved_action'
+  | 'no_evidence'
+  | 'upcoming_deadline'
+  | 'missing_notes'
+  | 'overdue_follow_up'
+  | 'ageing_follow_up'
+  | 'surfaced_follow_up'
+  | 'action_overload'
+
+export interface Signal {
+  type: SignalType
+  severity: SignalSeverity
+  message: string
+  personId?: string
+  personName?: string
+  entityId: string
+  entityType: 'task' | 'person' | 'meeting' | 'follow_up'
+  meta?: Record<string, unknown>
+}
+
+/** Weight table — higher = more attention needed */
+export const SIGNAL_WEIGHTS: Record<SignalType, number> = {
+  no_recent_1on1: 3,        // 14-20 days: warning weight
+  overdue_task: 3,
+  unresolved_action: 3,
+  no_evidence: 2,
+  upcoming_deadline: 0,     // info only, no attention weight
+  missing_notes: 2,
+  overdue_follow_up: 4,
+  ageing_follow_up: 3,
+  surfaced_follow_up: 5,
+  action_overload: 3,
+}
+
+/** Critical signals get a bonus weight */
+export const CRITICAL_BONUS = 2
+
+export function computeAttentionScore(signals: Signal[]): number {
+  return signals.reduce((sum, s) => {
+    const base = SIGNAL_WEIGHTS[s.type] ?? 1
+    const bonus = s.severity === 'critical' ? CRITICAL_BONUS : 0
+    return sum + base + bonus
+  }, 0)
+}
+
+export function scoreToColor(score: number): string {
+  if (score === 0) return '#00f058'
+  if (score <= 5) return '#ffd43b'
+  if (score <= 10) return '#ffa94d'
+  return '#ff6b6b'
+}
+
+export function scoreToBg(score: number): string {
+  if (score === 0) return '#0d1f14'
+  if (score <= 5) return '#2a2508'
+  if (score <= 10) return '#2a1a08'
+  return '#2a0a0a'
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -439,6 +439,129 @@ export interface Database {
           updated_at?: string
         }
       }
+      evidence_entries: {
+        Row: {
+          id: string
+          owning_user_id: string
+          person_id: string
+          category: 'achievement' | 'feedback_given' | 'feedback_received' | 'concern' | 'growth' | 'delivery' | 'behaviour' | 'promotion_evidence' | 'general'
+          title: string
+          content: string | null
+          occurred_at: string
+          meeting_id: string | null
+          task_id: string | null
+          sentiment: 'positive' | 'neutral' | 'negative' | null
+          review_period_start: string | null
+          review_period_end: string | null
+          included_in_review: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          owning_user_id: string
+          person_id: string
+          category: 'achievement' | 'feedback_given' | 'feedback_received' | 'concern' | 'growth' | 'delivery' | 'behaviour' | 'promotion_evidence' | 'general'
+          title: string
+          content?: string | null
+          occurred_at?: string
+          meeting_id?: string | null
+          task_id?: string | null
+          sentiment?: 'positive' | 'neutral' | 'negative' | null
+          review_period_start?: string | null
+          review_period_end?: string | null
+          included_in_review?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          owning_user_id?: string
+          person_id?: string
+          category?: 'achievement' | 'feedback_given' | 'feedback_received' | 'concern' | 'growth' | 'delivery' | 'behaviour' | 'promotion_evidence' | 'general'
+          title?: string
+          content?: string | null
+          occurred_at?: string
+          meeting_id?: string | null
+          task_id?: string | null
+          sentiment?: 'positive' | 'neutral' | 'negative' | null
+          review_period_start?: string | null
+          review_period_end?: string | null
+          included_in_review?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      review_cycles: {
+        Row: {
+          id: string
+          owning_user_id: string
+          name: string
+          start_date: string
+          end_date: string
+          status: 'active' | 'completed'
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          owning_user_id: string
+          name: string
+          start_date: string
+          end_date: string
+          status?: 'active' | 'completed'
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          owning_user_id?: string
+          name?: string
+          start_date?: string
+          end_date?: string
+          status?: 'active' | 'completed'
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      review_summaries: {
+        Row: {
+          id: string
+          owning_user_id: string
+          person_id: string
+          review_cycle_id: string | null
+          period_start: string
+          period_end: string
+          summary_text: string | null
+          manager_notes: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          owning_user_id: string
+          person_id: string
+          review_cycle_id?: string | null
+          period_start: string
+          period_end: string
+          summary_text?: string | null
+          manager_notes?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          owning_user_id?: string
+          person_id?: string
+          review_cycle_id?: string | null
+          period_start?: string
+          period_end?: string
+          summary_text?: string | null
+          manager_notes?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+      }
     }
     Views: {
       [_ in never]: never

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -556,6 +556,124 @@ CREATE POLICY "Users can delete own meeting templates" ON public.meeting_templat
   FOR DELETE USING (auth.uid() = owning_user_id);
 
 -- ============================================================================
+-- EVIDENCE ENTRIES TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.evidence_entries (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  owning_user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  person_id UUID NOT NULL REFERENCES public.people(id) ON DELETE CASCADE,
+  category TEXT NOT NULL CHECK (category IN (
+    'achievement', 'feedback_given', 'feedback_received', 'concern',
+    'growth', 'delivery', 'behaviour', 'promotion_evidence', 'general'
+  )),
+  title TEXT NOT NULL,
+  content TEXT,
+  occurred_at DATE NOT NULL DEFAULT CURRENT_DATE,
+  meeting_id UUID REFERENCES public.meetings(id) ON DELETE SET NULL,
+  task_id UUID REFERENCES public.tasks(id) ON DELETE SET NULL,
+  sentiment TEXT CHECK (sentiment IN ('positive', 'neutral', 'negative')),
+  review_period_start DATE,
+  review_period_end DATE,
+  included_in_review BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+CREATE INDEX idx_evidence_person ON public.evidence_entries(person_id, occurred_at DESC);
+CREATE INDEX idx_evidence_user ON public.evidence_entries(owning_user_id);
+CREATE INDEX idx_evidence_category ON public.evidence_entries(person_id, category);
+
+CREATE TRIGGER update_evidence_entries_updated_at
+  BEFORE UPDATE ON public.evidence_entries
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE public.evidence_entries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own evidence" ON public.evidence_entries
+  FOR SELECT USING (auth.uid() = owning_user_id);
+
+CREATE POLICY "Users can insert own evidence" ON public.evidence_entries
+  FOR INSERT WITH CHECK (auth.uid() = owning_user_id);
+
+CREATE POLICY "Users can update own evidence" ON public.evidence_entries
+  FOR UPDATE USING (auth.uid() = owning_user_id);
+
+CREATE POLICY "Users can delete own evidence" ON public.evidence_entries
+  FOR DELETE USING (auth.uid() = owning_user_id);
+
+-- ============================================================================
+-- REVIEW CYCLES TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.review_cycles (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  owning_user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  start_date DATE NOT NULL,
+  end_date DATE NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'completed')),
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+CREATE INDEX idx_review_cycles_user ON public.review_cycles(owning_user_id);
+
+CREATE TRIGGER update_review_cycles_updated_at
+  BEFORE UPDATE ON public.review_cycles
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE public.review_cycles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own review cycles" ON public.review_cycles
+  FOR SELECT USING (auth.uid() = owning_user_id);
+
+CREATE POLICY "Users can insert own review cycles" ON public.review_cycles
+  FOR INSERT WITH CHECK (auth.uid() = owning_user_id);
+
+CREATE POLICY "Users can update own review cycles" ON public.review_cycles
+  FOR UPDATE USING (auth.uid() = owning_user_id);
+
+CREATE POLICY "Users can delete own review cycles" ON public.review_cycles
+  FOR DELETE USING (auth.uid() = owning_user_id);
+
+-- ============================================================================
+-- REVIEW SUMMARIES TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.review_summaries (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  owning_user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  person_id UUID NOT NULL REFERENCES public.people(id) ON DELETE CASCADE,
+  review_cycle_id UUID REFERENCES public.review_cycles(id) ON DELETE SET NULL,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  summary_text TEXT,
+  manager_notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  UNIQUE (owning_user_id, person_id, period_start, period_end)
+);
+
+CREATE INDEX idx_review_summaries_person ON public.review_summaries(person_id);
+CREATE INDEX idx_review_summaries_user ON public.review_summaries(owning_user_id);
+
+CREATE TRIGGER update_review_summaries_updated_at
+  BEFORE UPDATE ON public.review_summaries
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE public.review_summaries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own review summaries" ON public.review_summaries
+  FOR SELECT USING (auth.uid() = owning_user_id);
+
+CREATE POLICY "Users can insert own review summaries" ON public.review_summaries
+  FOR INSERT WITH CHECK (auth.uid() = owning_user_id);
+
+CREATE POLICY "Users can update own review summaries" ON public.review_summaries
+  FOR UPDATE USING (auth.uid() = owning_user_id);
+
+CREATE POLICY "Users can delete own review summaries" ON public.review_summaries
+  FOR DELETE USING (auth.uid() = owning_user_id);
+
+-- ============================================================================
 -- SEED DATA (Optional - for development)
 -- ============================================================================
 -- Uncomment to add sample data after first user logs in

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS public.tasks (
 CREATE TABLE IF NOT EXISTS public.task_relations (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   task_id UUID NOT NULL REFERENCES public.tasks(id) ON DELETE CASCADE,
-  entity_type TEXT NOT NULL CHECK (entity_type IN ('person', 'team')),
+  entity_type TEXT NOT NULL CHECK (entity_type IN ('person', 'team', 'meeting')),
   entity_id UUID NOT NULL,
   created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
   -- Prevent duplicate relations
@@ -672,6 +672,106 @@ CREATE POLICY "Users can update own review summaries" ON public.review_summaries
 
 CREATE POLICY "Users can delete own review summaries" ON public.review_summaries
   FOR DELETE USING (auth.uid() = owning_user_id);
+
+-- ============================================================================
+-- FOLLOW UPS TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.follow_ups (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  person_id UUID NOT NULL REFERENCES public.people(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  description TEXT,
+  source_type TEXT CHECK (source_type IN ('meeting', 'manual', 'task')),
+  source_id UUID,
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'completed', 'cancelled')),
+  due_date DATE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  cancelled_at TIMESTAMPTZ,
+  last_surfaced_at TIMESTAMPTZ,
+  times_surfaced INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_follow_ups_person ON public.follow_ups(person_id, status);
+CREATE INDEX idx_follow_ups_user ON public.follow_ups(user_id, status);
+CREATE INDEX idx_follow_ups_due ON public.follow_ups(user_id, due_date) WHERE status = 'open';
+
+CREATE TRIGGER update_follow_ups_updated_at
+  BEFORE UPDATE ON public.follow_ups
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE public.follow_ups ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their own follow ups"
+  ON public.follow_ups
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- ============================================================================
+-- WEEKLY REVIEWS TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.weekly_reviews (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  week_start DATE NOT NULL,
+  status TEXT NOT NULL DEFAULT 'in_progress' CHECK (status IN ('in_progress', 'completed')),
+  completed_at TIMESTAMPTZ,
+  notes TEXT,
+  snapshot JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id, week_start)
+);
+
+CREATE INDEX idx_weekly_reviews_user_week ON public.weekly_reviews(user_id, week_start DESC);
+
+CREATE TRIGGER update_weekly_reviews_updated_at
+  BEFORE UPDATE ON public.weekly_reviews
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE public.weekly_reviews ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their own weekly reviews"
+  ON public.weekly_reviews
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- ============================================================================
+-- REVIEW DISMISSED ITEMS TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.review_dismissed_items (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  weekly_review_id UUID NOT NULL REFERENCES public.weekly_reviews(id) ON DELETE CASCADE,
+  item_type TEXT NOT NULL CHECK (item_type IN (
+    'overdue_task',
+    'no_recent_1on1',
+    'unresolved_action',
+    'no_evidence',
+    'upcoming_deadline',
+    'stale_goal',
+    'missing_notes'
+  )),
+  reference_id UUID,
+  reference_type TEXT,
+  dismissed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  note TEXT
+);
+
+CREATE INDEX idx_review_dismissed_review ON public.review_dismissed_items(weekly_review_id);
+CREATE INDEX idx_review_dismissed_user ON public.review_dismissed_items(user_id);
+
+ALTER TABLE public.review_dismissed_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their own dismissed items"
+  ON public.review_dismissed_items
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
 
 -- ============================================================================
 -- SEED DATA (Optional - for development)


### PR DESCRIPTION
## Summary

- **Weekly Review** (`/review`): guided 6-section weekly manager review with signal computation (overdue tasks, missing 1:1s, unresolved actions, no evidence), week navigation, dismiss flow with notes, reflection auto-save, completion snapshot, and sidebar indicator dot (red/orange/green)
- **People Radar** (`/radar`): person cards ranked by weighted attention score, signal breakdown with severity icons, quick actions (schedule 1:1, log evidence, add follow-up), expandable follow-ups section, stats bar, severity filter
- **Follow-up Engine**: create follow-ups from meetings, person detail, and radar; standalone `/follow-ups` page with person filter, overdue filter, and view modes; follow-up list on person detail page
- **Shared signals module** (`lib/signals/`): weighted attention scores, severity levels, color/bg helpers shared between radar and weekly review
- Attention indicators (colored dot) on people list rows and person detail header
- Track as Follow-up button on meeting detail view (1:1 meetings only)
- Sidebar: Weekly Review with status dot, People Radar and Follow-ups with count badges
- DB schema additions: `follow_ups`, `weekly_reviews`, `review_dismissed_items` tables with RLS; `task_relations` extended to support `entity_type = meeting`

## Test plan

- [ ] Run `npm run test:run` — 235 tests across 17 files should pass
- [ ] Apply DB schema changes (`supabase/schema.sql`) to Supabase instance
- [ ] Navigate to `/review` — verify signal sections populate, dismiss works, reflection saves, completion flow works
- [ ] Navigate to `/radar` — verify people ranked by score, quick actions open correct flows
- [ ] Navigate to `/follow-ups` — verify list, filters, and status changes work
- [ ] Open a 1:1 meeting — verify both Log as Evidence and Track as Follow-up buttons appear
- [ ] Check sidebar indicators update on page load