### PR TITLE
fix: high risk runtime and data integrity issues

### DIFF
--- a/app/(dashboard)/meetings/page.tsx
+++ b/app/(dashboard)/meetings/page.tsx
@@ -320,7 +320,11 @@ export default function MeetingsPage() {
       let parsed: { action_items: Array<{ title: string; assignee: string; due_date_hint: string | null }>; follow_ups: Array<{ title: string; person: string; due_date_hint: string | null }> }
       try {
         const jsonMatch = result.content.match(/\{[\s\S]*\}/)
-        parsed = JSON.parse(jsonMatch?.[0] ?? result.content)
+        if (!jsonMatch) {
+          toast.error('Could not parse AI response. Try again.')
+          return
+        }
+        parsed = JSON.parse(jsonMatch[0])
       } catch {
         toast.error('Could not parse AI response. Try again.')
         return

--- a/app/(dashboard)/people/[id]/page.tsx
+++ b/app/(dashboard)/people/[id]/page.tsx
@@ -80,14 +80,17 @@ export default function PersonDetailPage({ params }: { params: Promise<{ id: str
 
   useEffect(() => {
     if (!personId) return
-    getPeople().then(people => {
+    Promise.all([
+      getPeople(),
+      getTeams(),
+      getMeetingsForPerson(personId),
+      getFollowUpsForPerson(personId),
+    ]).then(([people, teams, backendMeetings, followUps]) => {
       const person = people.find(p => p.id === personId)
       if (person) setFormData(person)
       setAllPeopleNames(people.map(p => p.name))
       setAllPeopleWithIds(people.map(p => ({ id: p.id, name: p.name })))
-    }).catch(console.error)
-    getTeams().then(setAllTeams).catch(console.error)
-    getMeetingsForPerson(personId).then(backendMeetings => {
+      setAllTeams(teams)
       setMeetings(backendMeetings.map(m => ({
         id: m.id, title: m.title, type: m.meetingType, date: m.meetingDate,
         attendees: m.attendees,
@@ -96,8 +99,8 @@ export default function PersonDetailPage({ params }: { params: Promise<{ id: str
         actionItems: m.actionItems || undefined, notes: m.notes || undefined,
         personId: m.personId || undefined, teamId: m.teamId || undefined,
       })))
+      setFollowUps(followUps)
     }).catch(console.error)
-    getFollowUpsForPerson(personId).then(setFollowUps).catch(console.error)
   }, [personId])
 
   const tree = useMemo(() => {

--- a/app/(dashboard)/radar/page.tsx
+++ b/app/(dashboard)/radar/page.tsx
@@ -299,9 +299,9 @@ export default function RadarPage() {
         temperature: 0.2,
       })
       const jsonMatch = result.content.match(/\[[\s\S]*\]/)
-      if (jsonMatch) {
-        setRecurringTopics(JSON.parse(jsonMatch[0]))
-      } else {
+      try {
+        setRecurringTopics(jsonMatch ? JSON.parse(jsonMatch[0]) : [])
+      } catch {
         setRecurringTopics([])
       }
       setTopicsDetected(true)

--- a/app/(dashboard)/tasks/page.tsx
+++ b/app/(dashboard)/tasks/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { Task, TaskStatus, TASK_STATUSES } from "@/lib/types/task"
 import { getTasks, createTask, updateTask, deleteTask as deleteTaskService } from "@/lib/services/tasks"
 import {
@@ -40,10 +40,13 @@ export default function TasksPage() {
   const [isMounted, setIsMounted] = useState(false)
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
   const [, setIsLoading] = useState(true)
+  const mountedRef = useRef(true)
 
   // Load tasks from Supabase on mount
   useEffect(() => {
+    mountedRef.current = true
     loadTasks()
+    return () => { mountedRef.current = false }
   }, [])
 
   const loadTasks = async () => {
@@ -206,13 +209,14 @@ export default function TasksPage() {
 
       if (listChanged || statusChanged) {
         const updates = { list: currentTask.list, status: currentTask.status }
-        // Schedule DB write outside of the state updater
-        setTimeout(() => {
+        // DB write must happen outside state updater; guard against unmount
+        Promise.resolve().then(() => {
+          if (!mountedRef.current) return
           updateTask(activeId, updates).catch((error) => {
             console.error('Failed to update task:', error)
-            loadTasks()
+            if (mountedRef.current) loadTasks()
           })
-        }, 0)
+        })
       }
 
       return currentTasks

--- a/lib/services/people.ts
+++ b/lib/services/people.ts
@@ -43,12 +43,13 @@ function rowToPerson(person: PersonRow, teams: string[]): Person {
 export async function getPeople(): Promise<Person[]> {
   const supabase = createClient()
 
-  const [{ data: people, error }, { data: memberships }] = await Promise.all([
+  const [{ data: people, error }, { data: memberships, error: membershipsError }] = await Promise.all([
     supabase.from('people').select('*').order('created_at', { ascending: false }),
     supabase.from('team_memberships').select('person_id, teams(name)'),
   ])
 
   if (error) throw error
+  if (membershipsError) throw membershipsError
 
   const teamsByPerson: Record<string, string[]> = {}
   for (const m of memberships ?? []) {


### PR DESCRIPTION
## Summary

- **people.ts**: Throw on `team_memberships` query error — silent failure was dropping team associations
- **people/[id]**: Replace independent chained `.then()` calls with `Promise.all` — stale data possible when one fetch failed
- **tasks/page.tsx**: Replace `setTimeout(0)` DB write with `Promise.resolve()` + `mountedRef` guard — prevents setState on unmounted component
- **meetings/page.tsx**: Guard AI JSON regex match before `JSON.parse` — fallback to raw content caused double-failure
- **radar/page.tsx**: Wrap `JSON.parse` of AI response in try-catch — unguarded parse threw on missing JSON array

## Test plan

- [ ] People page loads with correct team badges
- [ ] Person detail page loads all data in parallel (check network tab — requests fire simultaneously)
- [ ] Drag task between columns, navigate away quickly — no console errors
- [ ] Trigger AI action item extraction with bad/empty notes — shows error toast, no crash
- [ ] Trigger recurring topics detection with unexpected AI response — falls back to empty list, no crash