### PR TITLE
fix: replace unsafe any casts with typed alternatives

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -22,7 +22,8 @@ async function getCalendarTasks(): Promise<CalendarTask[]> {
     blocked: "Blocked", completed: "Done",
   }
 
-  return (data ?? []).map((t: any) => ({
+  type TaskRow = { id: string; title: string; due_date: string; priority: string; status: string }
+  return (data ?? []).map((t: TaskRow) => ({
     id: t.id,
     title: t.title,
     dueDate: t.due_date,

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -103,8 +103,8 @@ export function DataTable<T extends { id?: number | string }>({
     }
 
     filtered.sort((a, b) => {
-      const aInactive = (a as any).status === "inactive" ? 1 : 0
-      const bInactive = (b as any).status === "inactive" ? 1 : 0
+      const aInactive = (a as { status?: string }).status === "inactive" ? 1 : 0
+      const bInactive = (b as { status?: string }).status === "inactive" ? 1 : 0
       return aInactive - bInactive
     })
 


### PR DESCRIPTION
## Summary

- **data-table.tsx**: Replace `(a as any).status` with `(a as { status?: string }).status` — restores TypeScript coverage on the inactive-sort comparator
- **dashboard/page.tsx**: Replace `(t: any)` cast on Supabase query result with explicit `TaskRow` interface — restores type checking on priority/status map lookups and makes unmapped DB values visible at compile time