### PR TITLE
feat: AI-powered task prioritisation (#100)

### DIFF
--- a/components/tasks/backlog-table.tsx
+++ b/components/tasks/backlog-table.tsx
@@ -1,13 +1,15 @@
 "use client"
 
-import { useState, useMemo } from "react"
+import { useState, useMemo, useCallback } from "react"
 import { Task, TaskStatus, TaskPriority, TaskCategory, TASK_STATUSES, TASK_PRIORITIES, TASK_CATEGORIES } from "@/lib/types/task"
 import { PRIORITY_BADGE, STATUS_BADGE } from "@/lib/badge-styles"
 import { BadgeSelect } from "@/components/ui/badge-select"
-import { Plus, ArrowUpDown, GripVertical, Search } from "lucide-react"
+import { Plus, ArrowUpDown, GripVertical, Search, Sparkles, X } from "lucide-react"
 import { useDroppable } from "@dnd-kit/core"
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import { DraggableTableRow } from "./draggable-table-row"
+import { prioritiseTasks, type TaskRanking } from "@/lib/services/tasks"
+import { handleAIError } from "@/lib/services/ai"
 
 interface BacklogTableProps {
   tasks: Task[]
@@ -29,6 +31,55 @@ export function BacklogTable({ tasks, onUpdateTask, onQuickAdd, onEdit, onDelete
   const [sortField, setSortField] = useState<SortField>("dueDate")
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc")
   const [showFilters, setShowFilters] = useState(false)
+
+  // AI prioritisation state
+  const [aiRankings, setAiRankings] = useState<TaskRanking[] | null>(null)
+  const [aiLoading, setAiLoading] = useState(false)
+  const [aiAbort, setAiAbort] = useState<AbortController | null>(null)
+
+  const handleAIPrioritise = useCallback(async () => {
+    if (aiLoading) {
+      aiAbort?.abort()
+      setAiLoading(false)
+      setAiAbort(null)
+      return
+    }
+
+    if (aiRankings) {
+      // Toggle off
+      setAiRankings(null)
+      return
+    }
+
+    const controller = new AbortController()
+    setAiAbort(controller)
+    setAiLoading(true)
+
+    try {
+      const today = new Date().toISOString().split("T")[0]
+      const input = tasks.map((t) => ({
+        id: t.id,
+        title: t.title,
+        priority: t.priority,
+        dueDate: t.dueDate,
+        category: t.category,
+        status: t.status,
+      }))
+      const rankings = await prioritiseTasks(input, today, controller.signal)
+      setAiRankings(rankings)
+    } catch (err) {
+      handleAIError(err)
+    } finally {
+      setAiLoading(false)
+      setAiAbort(null)
+    }
+  }, [aiLoading, aiRankings, aiAbort, tasks])
+
+  // Build a rank lookup map: taskId → { rank, reason }
+  const rankMap = useMemo<Map<string, TaskRanking>>(() => {
+    if (!aiRankings) return new Map()
+    return new Map(aiRankings.map((r) => [r.taskId, r]))
+  }, [aiRankings])
 
   const { setNodeRef, isOver } = useDroppable({
     id: "backlog-table",
@@ -53,37 +104,46 @@ export function BacklogTable({ tasks, onUpdateTask, onQuickAdd, onEdit, onDelete
       return matchesSearch && matchesStatus && matchesPriority && matchesCategory
     })
 
-    filtered.sort((a, b) => {
-      let comparison = 0
-      switch (sortField) {
-        case "title":
-          comparison = a.title.localeCompare(b.title)
-          break
-        case "dueDate": {
-          const dateA = a.dueDate ? new Date(a.dueDate).getTime() : Infinity
-          const dateB = b.dueDate ? new Date(b.dueDate).getTime() : Infinity
-          comparison = dateA - dateB
-          break
+    // When AI ranking is active, sort by AI rank; otherwise use manual sort
+    if (aiRankings && rankMap.size > 0) {
+      filtered.sort((a, b) => {
+        const rankA = rankMap.get(a.id)?.rank ?? Infinity
+        const rankB = rankMap.get(b.id)?.rank ?? Infinity
+        return rankA - rankB
+      })
+    } else {
+      filtered.sort((a, b) => {
+        let comparison = 0
+        switch (sortField) {
+          case "title":
+            comparison = a.title.localeCompare(b.title)
+            break
+          case "dueDate": {
+            const dateA = a.dueDate ? new Date(a.dueDate).getTime() : Infinity
+            const dateB = b.dueDate ? new Date(b.dueDate).getTime() : Infinity
+            comparison = dateA - dateB
+            break
+          }
+          case "priority": {
+            const priorityOrder: Record<TaskPriority, number> = { "Very High": 4, High: 3, Medium: 2, Low: 1 }
+            comparison = priorityOrder[a.priority] - priorityOrder[b.priority]
+            break
+          }
+          case "status": {
+            const statusOrder = { "Not started": 1, "In progress": 2, "Blocked": 3, "Done": 4 }
+            comparison = statusOrder[a.status] - statusOrder[b.status]
+            break
+          }
+          case "category":
+            comparison = a.category.localeCompare(b.category)
+            break
         }
-        case "priority": {
-          const priorityOrder: Record<TaskPriority, number> = { "Very High": 4, High: 3, Medium: 2, Low: 1 }
-          comparison = priorityOrder[a.priority] - priorityOrder[b.priority]
-          break
-        }
-        case "status": {
-          const statusOrder = { "Not started": 1, "In progress": 2, "Blocked": 3, "Done": 4 }
-          comparison = statusOrder[a.status] - statusOrder[b.status]
-          break
-        }
-        case "category":
-          comparison = a.category.localeCompare(b.category)
-          break
-      }
-      return sortDirection === "asc" ? comparison : -comparison
-    })
+        return sortDirection === "asc" ? comparison : -comparison
+      })
+    }
 
     return filtered
-  }, [tasks, searchQuery, statusFilter, priorityFilter, categoryFilter, sortField, sortDirection])
+  }, [tasks, searchQuery, statusFilter, priorityFilter, categoryFilter, sortField, sortDirection, aiRankings, rankMap])
 
   const formatDate = (date: string | null) => {
     if (!date) return ""
@@ -149,27 +209,97 @@ export function BacklogTable({ tasks, onUpdateTask, onQuickAdd, onEdit, onDelete
           </button>
         </div>
 
-        {/* Right: New task */}
-        <button
-          onClick={onQuickAdd}
-          style={{
-            background: "linear-gradient(90deg, #00ffe5 0%, #00f058 100%)",
-            color: "#0a1a0a",
-            fontSize: "var(--text-caption)",
-            fontWeight: 600,
-            padding: "4px 10px",
-            borderRadius: "4px",
-            border: "none",
-            cursor: "pointer",
-            display: "flex",
-            alignItems: "center",
-            gap: "5px",
-          }}
-        >
-          <Plus className="h-3.5 w-3.5" />
-          New task
-        </button>
+        {/* Right: AI Prioritise + New task */}
+        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          {/* AI Prioritise button */}
+          <button
+            onClick={handleAIPrioritise}
+            title={aiRankings ? "Clear AI ranking" : "Rank backlog by AI"}
+            style={{
+              background: aiRankings
+                ? "rgba(124,58,237,0.15)"
+                : aiLoading
+                ? "rgba(124,58,237,0.08)"
+                : "transparent",
+              border: "1px solid",
+              borderColor: aiRankings || aiLoading ? "#7C3AED" : "var(--border-2)",
+              color: aiRankings || aiLoading ? "#a78bfa" : "var(--text-2)",
+              fontSize: "var(--text-label)",
+              fontWeight: 500,
+              padding: "5px 10px",
+              borderRadius: "6px",
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              gap: "5px",
+              transition: "all 0.15s",
+            }}
+            onMouseEnter={e => {
+              if (!aiRankings && !aiLoading) e.currentTarget.style.color = "var(--text-1)"
+            }}
+            onMouseLeave={e => {
+              if (!aiRankings && !aiLoading) e.currentTarget.style.color = "var(--text-2)"
+            }}
+          >
+            {aiRankings ? (
+              <>
+                <X className="h-3.5 w-3.5" />
+                Clear AI rank
+              </>
+            ) : aiLoading ? (
+              <>
+                <Sparkles className="h-3.5 w-3.5" style={{ animation: "pulse 1s infinite" }} />
+                Ranking…
+              </>
+            ) : (
+              <>
+                <Sparkles className="h-3.5 w-3.5" />
+                AI Prioritise
+              </>
+            )}
+          </button>
+
+          {/* New task */}
+          <button
+            onClick={onQuickAdd}
+            style={{
+              background: "linear-gradient(90deg, #00ffe5 0%, #00f058 100%)",
+              color: "#0a1a0a",
+              fontSize: "var(--text-caption)",
+              fontWeight: 600,
+              padding: "4px 10px",
+              borderRadius: "4px",
+              border: "none",
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              gap: "5px",
+            }}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New task
+          </button>
+        </div>
       </div>
+
+      {/* AI ranking active banner */}
+      {aiRankings && (
+        <div style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          padding: "8px 12px",
+          background: "rgba(124,58,237,0.08)",
+          border: "1px solid rgba(124,58,237,0.25)",
+          borderRadius: "6px",
+          marginBottom: "12px",
+          fontSize: "var(--text-label)",
+          color: "#a78bfa",
+        }}>
+          <Sparkles style={{ width: "13px", height: "13px", flexShrink: 0 }} />
+          <span>Backlog ranked by AI priority. Hover the rank number to see the reason. <strong style={{ color: "#c4b5fd" }}>Drag to reorder manually.</strong></span>
+        </div>
+      )}
 
       {/* Filter row */}
       {showFilters && (
@@ -227,6 +357,7 @@ export function BacklogTable({ tasks, onUpdateTask, onQuickAdd, onEdit, onDelete
         <table className="w-full border-collapse">
           <colgroup>
             <col style={{ width: "36px" }} />
+            {aiRankings && <col style={{ width: "52px" }} />}
             <col />
             <col style={{ width: "140px" }} />
             <col style={{ width: "120px" }} />
@@ -238,6 +369,14 @@ export function BacklogTable({ tasks, onUpdateTask, onQuickAdd, onEdit, onDelete
             <tr style={{ borderBottom: "1px solid var(--border-1)" }}>
               {/* Drag handle col */}
               <th style={{ padding: "8px 12px", background: "var(--surf)" }} />
+              {/* AI rank col header */}
+              {aiRankings && (
+                <th style={{ padding: "8px 6px", background: "var(--surf)", textAlign: "center" }}>
+                  <span style={{ fontSize: "var(--text-overline)", color: "#a78bfa", fontFamily: "var(--font-mono)", fontWeight: 600 }}>
+                    #
+                  </span>
+                </th>
+              )}
               {/* Sortable columns */}
               {(["title", "status", "dueDate", "priority", "category"] as SortField[]).map((field) => {
                 const labels: Record<SortField, string> = {
@@ -295,6 +434,37 @@ export function BacklogTable({ tasks, onUpdateTask, onQuickAdd, onEdit, onDelete
                       <GripVertical style={{ width: "14px", height: "14px", color: "var(--text-3)" }} />
                     </div>
                   </td>
+
+                  {/* AI rank badge */}
+                  {aiRankings && (() => {
+                    const ranking = rankMap.get(task.id)
+                    return (
+                      <td
+                        style={{ padding: "9px 6px", textAlign: "center" }}
+                        title={ranking?.reason ?? "Not ranked"}
+                      >
+                        {ranking ? (
+                          <span style={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            width: "22px",
+                            height: "22px",
+                            borderRadius: "50%",
+                            background: ranking.rank <= 3 ? "rgba(124,58,237,0.2)" : "var(--surf-3)",
+                            color: ranking.rank <= 3 ? "#a78bfa" : "var(--text-3)",
+                            fontSize: "var(--text-overline)",
+                            fontFamily: "var(--font-mono)",
+                            fontWeight: 700,
+                          }}>
+                            {ranking.rank}
+                          </span>
+                        ) : (
+                          <span style={{ color: "var(--text-3)", fontSize: "var(--text-overline)" }}>—</span>
+                        )}
+                      </td>
+                    )
+                  })()}
 
                   {/* Name */}
                   <td

--- a/lib/ai/__tests__/prompts.eval.test.ts
+++ b/lib/ai/__tests__/prompts.eval.test.ts
@@ -13,6 +13,7 @@ import {
   buildPromotionPacketPrompt,
   buildActionItemPrompt,
   buildGrowthPlanPrompt,
+  buildTaskPrioritisationPrompt,
   REVIEW_DRAFT_SYSTEM,
   ONE_ON_ONE_PREP_SYSTEM,
   PROMOTION_PACKET_SYSTEM,
@@ -22,6 +23,8 @@ import {
   REFLECTION_PROMPTS_SYSTEM,
   RECURRING_TOPICS_SYSTEM,
   SUMMARY_REWRITE_PROMPTS,
+  TASK_PRIORITISATION_SYSTEM,
+  type TaskPrioritisationInput,
 } from '../prompts'
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -402,5 +405,99 @@ describe('system prompt structure', () => {
     expect(ONE_ON_ONE_PREP_SYSTEM).toContain('Follow-up check-ins')
     expect(ONE_ON_ONE_PREP_SYSTEM).toContain('Suggested discussion topics')
     expect(ONE_ON_ONE_PREP_SYSTEM).toContain('Questions to ask')
+  })
+
+  it('task prioritisation system prompt demands JSON-only output', () => {
+    expect(TASK_PRIORITISATION_SYSTEM).toContain('"rankings"')
+    expect(TASK_PRIORITISATION_SYSTEM).toContain('"taskId"')
+    expect(TASK_PRIORITISATION_SYSTEM).toContain('"rank"')
+    expect(TASK_PRIORITISATION_SYSTEM).toContain('"reason"')
+    expect(TASK_PRIORITISATION_SYSTEM).toContain('No other text')
+  })
+
+  it('task prioritisation system prompt describes all ranking signals', () => {
+    expect(TASK_PRIORITISATION_SYSTEM).toContain('Urgency')
+    expect(TASK_PRIORITISATION_SYSTEM).toContain('Priority field')
+    expect(TASK_PRIORITISATION_SYSTEM).toContain('Person workload')
+    expect(TASK_PRIORITISATION_SYSTEM).toContain('Category')
+  })
+})
+
+// ─── Task Prioritisation Prompt ───────────────────────────────────────────────
+
+const TASKS: TaskPrioritisationInput[] = [
+  { id: 'task-1', title: 'Write Q2 performance reviews', priority: 'Very High', dueDate: '2026-05-20', category: 'People', status: 'Not started' },
+  { id: 'task-2', title: 'Update team roadmap doc', priority: 'Medium', dueDate: '2026-06-01', category: 'Task', status: 'Not started' },
+  { id: 'task-3', title: 'Fix CI pipeline', priority: 'High', dueDate: null, category: 'Task', status: 'In progress', linkedPersonName: 'Alice', personOpenTaskCount: 8 },
+]
+
+describe('buildTaskPrioritisationPrompt', () => {
+  it('includes all task IDs in prompt', () => {
+    const prompt = buildTaskPrioritisationPrompt({ tasks: TASKS, today: '2026-05-23' })
+    expect(prompt).toContain('task-1')
+    expect(prompt).toContain('task-2')
+    expect(prompt).toContain('task-3')
+  })
+
+  it('marks overdue tasks explicitly', () => {
+    const prompt = buildTaskPrioritisationPrompt({ tasks: TASKS, today: '2026-05-23' })
+    // task-1 due 2026-05-20, today is 2026-05-23 → overdue
+    expect(prompt).toContain('OVERDUE')
+    expect(prompt).toContain('2026-05-20')
+  })
+
+  it('includes linked person name and open task count', () => {
+    const prompt = buildTaskPrioritisationPrompt({ tasks: TASKS, today: '2026-05-23' })
+    expect(prompt).toContain('Alice')
+    expect(prompt).toContain('8 open tasks')
+  })
+
+  it('includes today date in prompt', () => {
+    const prompt = buildTaskPrioritisationPrompt({ tasks: TASKS, today: '2026-05-23' })
+    expect(prompt).toContain('Today: 2026-05-23')
+  })
+
+  it('includes priority and category for each task', () => {
+    const prompt = buildTaskPrioritisationPrompt({ tasks: TASKS, today: '2026-05-23' })
+    expect(prompt).toContain('Very High')
+    expect(prompt).toContain('People')
+    expect(prompt).toContain('Medium')
+  })
+
+  it('returns early message for empty task list', () => {
+    const prompt = buildTaskPrioritisationPrompt({ tasks: [], today: '2026-05-23' })
+    expect(prompt).toContain('No tasks to prioritise')
+  })
+
+  it('stays within 4000 token budget (~16000 chars)', () => {
+    const largeTasks: TaskPrioritisationInput[] = Array.from({ length: 200 }, (_, i) => ({
+      id: `task-${i}`,
+      title: `Task ${i} with a reasonably long title that could bloat the prompt`,
+      priority: 'High',
+      dueDate: '2026-06-01',
+      category: 'Task',
+      status: 'Not started',
+      linkedPersonName: 'Alice Smith',
+      personOpenTaskCount: 12,
+    }))
+    const prompt = buildTaskPrioritisationPrompt({ tasks: largeTasks, today: '2026-05-23' })
+    expect(prompt.length).toBeLessThanOrEqual(16500)
+  })
+
+  it('handles tasks with no due date gracefully', () => {
+    const tasks: TaskPrioritisationInput[] = [
+      { id: 'task-x', title: 'No deadline task', priority: 'Low', dueDate: null, category: 'Task', status: 'Not started' },
+    ]
+    const prompt = buildTaskPrioritisationPrompt({ tasks, today: '2026-05-23' })
+    expect(prompt).toContain('no due date')
+  })
+
+  it('handles tasks without linked person', () => {
+    const tasks: TaskPrioritisationInput[] = [
+      { id: 'task-y', title: 'Standalone task', priority: 'Medium', dueDate: '2026-06-15', category: 'Task', status: 'Not started' },
+    ]
+    const prompt = buildTaskPrioritisationPrompt({ tasks, today: '2026-05-23' })
+    // No person info — should not contain "linked to"
+    expect(prompt).not.toContain('linked to')
   })
 })

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -287,3 +287,70 @@ For each recurring topic return:
 - escalating: boolean — is the topic becoming more prominent or urgent over time?
 
 Return ONLY a JSON array. If no recurring topics, return [].`
+
+// ─── Task Prioritisation ──────────────────────────────────────────────────────
+
+export const TASK_PRIORITISATION_SYSTEM = `You are helping an engineering manager prioritise their task backlog. Rank tasks by importance using the following signals:
+
+1. **Urgency** — How soon is it due? Overdue tasks rank highest.
+2. **Priority field** — Very High > High > Medium > Low. Weight this heavily.
+3. **Person workload** — Tasks linked to people with high open-task counts are more important to resolve.
+4. **Category** — People-related tasks (1:1s, performance, career) rank above general tasks when urgency is equal.
+
+Return ONLY a JSON object:
+{
+  "rankings": [
+    { "taskId": "...", "rank": 1, "reason": "..." },
+    ...
+  ]
+}
+
+Rules:
+- Every task in the input must appear in rankings exactly once
+- rank 1 = highest priority
+- reason must be one concise sentence (max 15 words) explaining why this rank
+- Do not fabricate tasks that were not in the input
+- No other text outside the JSON`
+
+export interface TaskPrioritisationInput {
+  id: string
+  title: string
+  priority: string
+  dueDate: string | null
+  category: string
+  status: string
+  linkedPersonName?: string
+  personOpenTaskCount?: number
+}
+
+export interface TaskRanking {
+  taskId: string
+  rank: number
+  reason: string
+}
+
+export interface TaskPrioritisationResult {
+  rankings: TaskRanking[]
+}
+
+export function buildTaskPrioritisationPrompt(args: {
+  tasks: TaskPrioritisationInput[]
+  today: string
+}): string {
+  if (args.tasks.length === 0) return 'No tasks to prioritise.'
+
+  const taskLines = args.tasks.map(t => {
+    const due = t.dueDate
+      ? (t.dueDate < args.today ? `OVERDUE (was ${t.dueDate})` : `due ${t.dueDate}`)
+      : 'no due date'
+    const person = t.linkedPersonName
+      ? `, linked to ${t.linkedPersonName}${t.personOpenTaskCount != null ? ` (${t.personOpenTaskCount} open tasks)` : ''}`
+      : ''
+    return `- id:${t.id} | "${t.title}" | priority:${t.priority} | ${due} | category:${t.category} | status:${t.status}${person}`
+  }).join('\n')
+
+  return truncateToTokenBudget(`Today: ${args.today}
+
+Tasks to rank:
+${taskLines}`, 4000)
+}

--- a/lib/services/__tests__/tasks.prioritise.test.ts
+++ b/lib/services/__tests__/tasks.prioritise.test.ts
@@ -1,0 +1,153 @@
+/**
+ * prioritiseTasks service — unit tests
+ * Mocks callAI; does NOT make real network calls.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prioritiseTasks } from '../tasks'
+import type { TaskPrioritisationInput } from '../tasks'
+
+// ─── Mock callAI ──────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/services/ai', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/services/ai')>()
+  return {
+    ...actual,
+    callAI: vi.fn(),
+  }
+})
+
+// Mock supabase (required by tasks.ts module import chain)
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null }),
+    },
+    from: vi.fn(),
+  })),
+}))
+
+import { callAI } from '@/lib/services/ai'
+const mockCallAI = vi.mocked(callAI)
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const TASKS: TaskPrioritisationInput[] = [
+  { id: 'task-1', title: 'Write Q2 performance reviews', priority: 'Very High', dueDate: '2026-05-20', category: 'People', status: 'Not started' },
+  { id: 'task-2', title: 'Update team roadmap', priority: 'Medium', dueDate: '2026-06-01', category: 'Task', status: 'Not started' },
+  { id: 'task-3', title: 'Fix CI pipeline', priority: 'High', dueDate: null, category: 'Task', status: 'In progress', linkedPersonName: 'Alice', personOpenTaskCount: 8 },
+]
+
+const VALID_RESPONSE = {
+  content: JSON.stringify({
+    rankings: [
+      { taskId: 'task-1', rank: 1, reason: 'Overdue and Very High priority.' },
+      { taskId: 'task-3', rank: 2, reason: 'High priority with team member overloaded.' },
+      { taskId: 'task-2', rank: 3, reason: 'Medium priority with future due date.' },
+    ],
+  }),
+  tokensUsed: { input: 300, output: 80 },
+  model: 'claude-sonnet-4-6',
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('prioritiseTasks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty array for empty task list (no AI call)', async () => {
+    const result = await prioritiseTasks([], '2026-05-23')
+    expect(result).toEqual([])
+    expect(mockCallAI).not.toHaveBeenCalled()
+  })
+
+  it('returns rankings sorted by rank ascending', async () => {
+    mockCallAI.mockResolvedValue(VALID_RESPONSE)
+    const result = await prioritiseTasks(TASKS, '2026-05-23')
+    expect(result[0].taskId).toBe('task-1')
+    expect(result[1].taskId).toBe('task-3')
+    expect(result[2].taskId).toBe('task-2')
+    expect(result[0].rank).toBe(1)
+    expect(result[2].rank).toBe(3)
+  })
+
+  it('returns reason string for each ranking', async () => {
+    mockCallAI.mockResolvedValue(VALID_RESPONSE)
+    const result = await prioritiseTasks(TASKS, '2026-05-23')
+    for (const r of result) {
+      expect(typeof r.reason).toBe('string')
+      expect(r.reason.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('calls callAI with correct system prompt and temperature:0', async () => {
+    mockCallAI.mockResolvedValue(VALID_RESPONSE)
+    await prioritiseTasks(TASKS, '2026-05-23')
+    expect(mockCallAI).toHaveBeenCalledOnce()
+    const [req] = mockCallAI.mock.calls[0]
+    expect(req.temperature).toBe(0)
+    expect(req.systemPrompt).toContain('"rankings"')
+  })
+
+  it('user prompt contains all task IDs', async () => {
+    mockCallAI.mockResolvedValue(VALID_RESPONSE)
+    await prioritiseTasks(TASKS, '2026-05-23')
+    const [req] = mockCallAI.mock.calls[0]
+    expect(req.userPrompt).toContain('task-1')
+    expect(req.userPrompt).toContain('task-2')
+    expect(req.userPrompt).toContain('task-3')
+  })
+
+  it('strips markdown code fences from AI response', async () => {
+    mockCallAI.mockResolvedValue({
+      ...VALID_RESPONSE,
+      content: '```json\n' + JSON.stringify({ rankings: [{ taskId: 'task-1', rank: 1, reason: 'Top priority.' }] }) + '\n```',
+    })
+    const result = await prioritiseTasks([TASKS[0]], '2026-05-23')
+    expect(result[0].taskId).toBe('task-1')
+  })
+
+  it('throws on invalid JSON from AI', async () => {
+    mockCallAI.mockResolvedValue({ ...VALID_RESPONSE, content: 'not json at all' })
+    await expect(prioritiseTasks(TASKS, '2026-05-23')).rejects.toThrow('invalid JSON')
+  })
+
+  it('throws when rankings array is missing from response', async () => {
+    mockCallAI.mockResolvedValue({ ...VALID_RESPONSE, content: JSON.stringify({ something_else: [] }) })
+    await expect(prioritiseTasks(TASKS, '2026-05-23')).rejects.toThrow('missing rankings array')
+  })
+
+  it('filters out malformed ranking entries', async () => {
+    mockCallAI.mockResolvedValue({
+      ...VALID_RESPONSE,
+      content: JSON.stringify({
+        rankings: [
+          { taskId: 'task-1', rank: 1, reason: 'Valid entry.' },
+          { taskId: 123, rank: 2, reason: 'Bad taskId type — should be filtered.' }, // invalid: taskId not string
+          { taskId: 'task-3', rank: 3 }, // missing reason — filtered
+        ],
+      }),
+    })
+    const result = await prioritiseTasks(TASKS, '2026-05-23')
+    expect(result).toHaveLength(1)
+    expect(result[0].taskId).toBe('task-1')
+  })
+
+  it('passes AbortSignal through to callAI', async () => {
+    mockCallAI.mockResolvedValue(VALID_RESPONSE)
+    const controller = new AbortController()
+    await prioritiseTasks(TASKS, '2026-05-23', controller.signal)
+    const [, signal] = mockCallAI.mock.calls[0]
+    expect(signal).toBe(controller.signal)
+  })
+
+  it('uses current date when today param is omitted', async () => {
+    mockCallAI.mockResolvedValue(VALID_RESPONSE)
+    await prioritiseTasks(TASKS)
+    const [req] = mockCallAI.mock.calls[0]
+    const todayPattern = /Today: \d{4}-\d{2}-\d{2}/
+    expect(req.userPrompt).toMatch(todayPattern)
+  })
+})

--- a/lib/services/tasks.ts
+++ b/lib/services/tasks.ts
@@ -5,6 +5,16 @@
 
 import { createClient } from '@/lib/supabase/client'
 import type { Task, TaskStatus, TaskPriority, TaskCategory } from '@/lib/types/task'
+import { callAI } from '@/lib/services/ai'
+import {
+  TASK_PRIORITISATION_SYSTEM,
+  buildTaskPrioritisationPrompt,
+  type TaskPrioritisationInput,
+  type TaskRanking,
+  type TaskPrioritisationResult,
+} from '@/lib/ai/prompts'
+
+export type { TaskPrioritisationInput, TaskRanking, TaskPrioritisationResult }
 
 type DbPriority = 'low' | 'medium' | 'high' | 'very_high'
 type DbStatus = 'not_started' | 'in_progress' | 'blocked' | 'completed'
@@ -205,4 +215,53 @@ export async function deleteTask(id: string): Promise<void> {
 
 export async function moveTask(id: string, toList: 'week' | 'backlog'): Promise<Task> {
   return updateTask(id, { list: toList })
+}
+
+/**
+ * Prioritise a list of tasks using AI.
+ * Returns rankings ordered by rank (1 = highest priority).
+ * Throws if the AI response cannot be parsed.
+ */
+export async function prioritiseTasks(
+  tasks: TaskPrioritisationInput[],
+  today: string = new Date().toISOString().split('T')[0],
+  signal?: AbortSignal
+): Promise<TaskRanking[]> {
+  if (tasks.length === 0) return []
+
+  const userPrompt = buildTaskPrioritisationPrompt({ tasks, today })
+
+  const response = await callAI(
+    {
+      systemPrompt: TASK_PRIORITISATION_SYSTEM,
+      userPrompt,
+      maxTokens: 1000,
+      temperature: 0,
+    },
+    signal
+  )
+
+  let parsed: TaskPrioritisationResult
+  try {
+    // Strip markdown code fences if present
+    const cleaned = response.content.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim()
+    parsed = JSON.parse(cleaned) as TaskPrioritisationResult
+  } catch {
+    throw new Error('AI returned invalid JSON for task prioritisation')
+  }
+
+  if (!Array.isArray(parsed.rankings)) {
+    throw new Error('AI response missing rankings array')
+  }
+
+  // Validate and sort by rank
+  const rankings = parsed.rankings
+    .filter((r): r is TaskRanking =>
+      typeof r.taskId === 'string' &&
+      typeof r.rank === 'number' &&
+      typeof r.reason === 'string'
+    )
+    .sort((a, b) => a.rank - b.rank)
+
+  return rankings
 }


### PR DESCRIPTION
## Summary

Implements [#100](https://github.com/shiphrahx/Caliber/issues/100) — AI-powered backlog prioritisation. Manager clicks one button to rank their entire backlog by urgency, priority, person workload, and category. Each task gets a rank badge with a one-sentence reason on hover.

## Changes

### `lib/ai/prompts.ts`
- `TASK_PRIORITISATION_SYSTEM` — system prompt ranking by 4 signals: urgency, priority field, person workload, category
- `buildTaskPrioritisationPrompt` — assembles task context (overdue marking, person open-task count, token-budget capped at 4000)
- Exported types: `TaskPrioritisationInput`, `TaskRanking`, `TaskPrioritisationResult`

### `lib/services/tasks.ts`
- `prioritiseTasks(tasks, today?, signal?)` — calls AI, strips markdown code fences, validates/filters response, returns rankings sorted by rank ascending
- Returns empty array for empty input (no AI call)
- Throws with clear messages on invalid JSON or missing rankings array

### `components/tasks/backlog-table.tsx`
- **AI Prioritise button** (Sparkles icon) in the controls row — toggles ranking on/off
- When active: backlog sorted by AI rank, purple rank badge (#1–N) on each row, reason shown in hover tooltip
- Info banner while ranking is active with instructions
- Click again or "Clear AI rank" to revert to manual sort
- AbortController wired up — clicking while loading cancels the in-flight request

### Tests
- **`lib/ai/__tests__/prompts.eval.test.ts`** — 9 new tests covering system prompt structure, overdue marking, person context, token budget, empty inputs, edge cases
- **`lib/services/__tests__/tasks.prioritise.test.ts`** — 11 new unit tests covering happy path, code fence stripping, JSON error handling, malformed entry filtering, AbortSignal passthrough

## Test Results
- 353 tests total, 351 passing
- 2 pre-existing failures in `task-card.test.tsx` (date-dependent "Today"/"Tomorrow" label tests — present on `master` before this branch)

## Closes
Closes #100

---