### PR TITLE
feat: meeting prep auto-trigger before 1:1s (#101)

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { TasksWidget } from "@/components/dashboard/tasks-widget"
 import { TaskPriorityChart } from "@/components/dashboard/task-priority-chart"
 import { DashboardCalendar, CalendarTask } from "@/components/dashboard/dashboard-calendar"
 import { WeeklyReviewBanner } from "@/components/dashboard/weekly-review-banner"
+import { UpcomingOneOnOnes } from "@/components/dashboard/upcoming-one-on-ones"
 
 async function getCalendarTasks(): Promise<CalendarTask[]> {
   const supabase = await createClient()
@@ -53,6 +54,9 @@ export default async function DashboardPage() {
 
       {/* Weekly Review prompt */}
       <WeeklyReviewBanner />
+
+      {/* Upcoming 1:1s with AI prep briefs */}
+      <UpcomingOneOnOnes />
 
       {/* ── Widgets row ── */}
       <div className="grid grid-cols-3 gap-4">

--- a/components/dashboard/upcoming-one-on-ones.tsx
+++ b/components/dashboard/upcoming-one-on-ones.tsx
@@ -1,0 +1,278 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import Link from "next/link"
+import { Sparkles, ChevronDown, ChevronUp, ExternalLink, Calendar } from "lucide-react"
+import { getUpcoming1on1s, type Meeting } from "@/lib/services/meetings"
+import { generatePrepBrief, type PrepBrief } from "@/lib/services/prep-brief"
+import { handleAIError } from "@/lib/services/ai"
+
+// ─── Per-meeting prep card ─────────────────────────────────────────────────
+
+interface PrepCardProps {
+  meeting: Meeting
+}
+
+function PrepCard({ meeting }: PrepCardProps) {
+  const [brief, setBrief] = useState<PrepBrief | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [expanded, setExpanded] = useState(false)
+  const [abortController, setAbortController] = useState<AbortController | null>(null)
+
+  const isToday = meeting.meetingDate === new Date().toISOString().split("T")[0]
+  const dateLabel = isToday ? "Today" : "Tomorrow"
+
+  const handleGenerate = useCallback(async () => {
+    if (!meeting.personId) return
+
+    if (loading) {
+      abortController?.abort()
+      setLoading(false)
+      setAbortController(null)
+      return
+    }
+
+    const controller = new AbortController()
+    setAbortController(controller)
+    setLoading(true)
+
+    try {
+      const result = await generatePrepBrief(meeting.personId, controller.signal)
+      setBrief(result)
+      setExpanded(true)
+    } catch (err) {
+      handleAIError(err)
+    } finally {
+      setLoading(false)
+      setAbortController(null)
+    }
+  }, [meeting.personId, loading, abortController])
+
+  return (
+    <div
+      data-testid="prep-card"
+      style={{
+        background: "var(--surf)",
+        border: "1px solid var(--border-1)",
+        borderRadius: "10px",
+        overflow: "hidden",
+      }}
+    >
+      {/* Card header */}
+      <div style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "10px",
+        padding: "12px 14px",
+      }}>
+        {/* Date chip */}
+        <span style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "4px",
+          padding: "2px 8px",
+          borderRadius: "4px",
+          background: isToday ? "rgba(0,255,229,0.1)" : "var(--surf-3)",
+          color: isToday ? "#00ffe5" : "var(--text-3)",
+          fontSize: "var(--text-overline)",
+          fontFamily: "var(--font-mono)",
+          fontWeight: 600,
+          flexShrink: 0,
+        }}>
+          <Calendar style={{ width: "10px", height: "10px" }} />
+          {dateLabel}
+        </span>
+
+        {/* Person name + title */}
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{
+            fontSize: "var(--text-body)",
+            fontWeight: 600,
+            color: "var(--text-1)",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}>
+            {meeting.personName ?? meeting.title}
+          </div>
+          {meeting.personName && (
+            <div style={{
+              fontSize: "var(--text-caption)",
+              color: "var(--text-3)",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}>
+              {meeting.title}
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div style={{ display: "flex", alignItems: "center", gap: "6px", flexShrink: 0 }}>
+          {/* Link to person page */}
+          {meeting.personId && (
+            <Link
+              href={`/people/${meeting.personId}`}
+              onClick={(e) => e.stopPropagation()}
+              title="View person"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                padding: "4px",
+                borderRadius: "4px",
+                color: "var(--text-3)",
+                textDecoration: "none",
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.color = "var(--text-1)")}
+              onMouseLeave={(e) => (e.currentTarget.style.color = "var(--text-3)")}
+            >
+              <ExternalLink style={{ width: "12px", height: "12px" }} />
+            </Link>
+          )}
+
+          {/* Generate / toggle button */}
+          <button
+            onClick={brief ? () => setExpanded((v) => !v) : handleGenerate}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "5px",
+              padding: "4px 10px",
+              borderRadius: "5px",
+              border: "1px solid",
+              borderColor: brief ? "var(--border-2)" : "#7C3AED",
+              background: brief ? "transparent" : "rgba(124,58,237,0.12)",
+              color: brief ? "var(--text-2)" : "#a78bfa",
+              fontSize: "var(--text-label)",
+              fontWeight: 500,
+              cursor: "pointer",
+              transition: "all 0.15s",
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.color = "var(--text-1)"
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.color = brief ? "var(--text-2)" : "#a78bfa"
+            }}
+          >
+            {loading ? (
+              <>
+                <Sparkles style={{ width: "12px", height: "12px", animation: "pulse 1s infinite" }} />
+                Preparing…
+              </>
+            ) : brief ? (
+              <>
+                {expanded ? <ChevronUp style={{ width: "12px", height: "12px" }} /> : <ChevronDown style={{ width: "12px", height: "12px" }} />}
+                {expanded ? "Hide" : "View prep"}
+              </>
+            ) : (
+              <>
+                <Sparkles style={{ width: "12px", height: "12px" }} />
+                Prep brief
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Brief content */}
+      {brief && expanded && (
+        <div style={{
+          borderTop: "1px solid var(--border-1)",
+          padding: "14px 16px",
+          background: "var(--surf-2)",
+        }}>
+          <div
+            data-testid="brief-content"
+            style={{
+              fontSize: "var(--text-meta)",
+              color: "var(--text-2)",
+              lineHeight: 1.6,
+              whiteSpace: "pre-wrap",
+              maxHeight: "300px",
+              overflowY: "auto",
+            }}
+          >
+            {brief.content}
+          </div>
+          <div style={{
+            marginTop: "10px",
+            fontSize: "var(--text-caption)",
+            color: "var(--text-3)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}>
+            <span>Generated at {new Date(brief.generatedAt).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" })}</span>
+            <button
+              onClick={handleGenerate}
+              style={{
+                background: "none",
+                border: "none",
+                color: "var(--text-3)",
+                fontSize: "var(--text-caption)",
+                cursor: "pointer",
+                padding: 0,
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.color = "var(--text-1)")}
+              onMouseLeave={(e) => (e.currentTarget.style.color = "var(--text-3)")}
+            >
+              Regenerate
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Widget ────────────────────────────────────────────────────────────────────
+
+export function UpcomingOneOnOnes() {
+  const [meetings, setMeetings] = useState<Meeting[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const today = new Date().toISOString().split("T")[0]
+    getUpcoming1on1s(today)
+      .then(setMeetings)
+      .catch(() => {/* non-critical widget */})
+      .finally(() => setLoading(false))
+  }, [])
+
+  // Don't render when no upcoming 1:1s or still loading
+  if (loading || meetings.length === 0) return null
+
+  return (
+    <div
+      data-testid="upcoming-one-on-ones"
+      style={{
+        background: "var(--surf)",
+        border: "1px solid var(--border-1)",
+        borderRadius: "12px",
+        padding: "20px",
+      }}
+    >
+      {/* Header */}
+      <div style={{ marginBottom: "14px" }}>
+        <h2 style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <Sparkles style={{ width: "15px", height: "15px", color: "#a78bfa" }} />
+          Upcoming 1:1s
+        </h2>
+        <p style={{ marginTop: "2px", fontSize: "var(--text-meta)", color: "var(--text-3)" }}>
+          {meetings.length === 1
+            ? "You have 1 upcoming 1:1. Generate a prep brief to get ready."
+            : `You have ${meetings.length} upcoming 1:1s. Generate prep briefs to get ready.`}
+        </p>
+      </div>
+
+      {/* Cards */}
+      <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+        {meetings.map((meeting) => (
+          <PrepCard key={meeting.id} meeting={meeting} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/lib/services/__tests__/meetings.upcoming.test.ts
+++ b/lib/services/__tests__/meetings.upcoming.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for getUpcoming1on1s
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getUpcoming1on1s } from '../meetings'
+import { createClient } from '@/lib/supabase/client'
+
+vi.mock('@/lib/supabase/client')
+
+const mockMeetingRow = (overrides: Record<string, unknown> = {}) => ({
+  id: 'meeting-1',
+  title: '1:1 with Alice',
+  meeting_type: '1:1',
+  meeting_date: '2026-05-23',
+  next_meeting_date: null,
+  recurrence: null,
+  action_items: null,
+  notes: null,
+  person_id: 'person-1',
+  team_id: null,
+  person: { full_name: 'Alice Chen' },
+  team: null,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  ...overrides,
+})
+
+function makeMockSupabase(rows: unknown[]) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    lte: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
+    order: vi.fn().mockResolvedValue({ data: rows, error: null }),
+  }
+  return {
+    from: vi.fn().mockReturnValue(chain),
+    auth: { getUser: vi.fn() },
+    _chain: chain,
+  }
+}
+
+describe('getUpcoming1on1s', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns upcoming 1:1s for today and tomorrow', async () => {
+    const mockSupabase = makeMockSupabase([mockMeetingRow()])
+    ;(createClient as ReturnType<typeof vi.fn>).mockReturnValue(mockSupabase)
+
+    const result = await getUpcoming1on1s('2026-05-23')
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('meeting-1')
+    expect(result[0].meetingType).toBe('1:1')
+    expect(result[0].personName).toBe('Alice Chen')
+  })
+
+  it('queries only meeting_type=1:1 with person_id', async () => {
+    const mockSupabase = makeMockSupabase([])
+    ;(createClient as ReturnType<typeof vi.fn>).mockReturnValue(mockSupabase)
+
+    await getUpcoming1on1s('2026-05-23')
+
+    const chain = mockSupabase._chain
+    // eq called with meeting_type = '1:1'
+    expect(chain.eq).toHaveBeenCalledWith('meeting_type', '1:1')
+    // not called to filter person_id not null
+    expect(chain.not).toHaveBeenCalledWith('person_id', 'is', null)
+  })
+
+  it('queries date range today to tomorrow', async () => {
+    const mockSupabase = makeMockSupabase([])
+    ;(createClient as ReturnType<typeof vi.fn>).mockReturnValue(mockSupabase)
+
+    await getUpcoming1on1s('2026-05-23')
+
+    const chain = mockSupabase._chain
+    expect(chain.gte).toHaveBeenCalledWith('meeting_date', '2026-05-23')
+    expect(chain.lte).toHaveBeenCalledWith('meeting_date', '2026-05-24')
+  })
+
+  it('returns empty array when no upcoming 1:1s', async () => {
+    const mockSupabase = makeMockSupabase([])
+    ;(createClient as ReturnType<typeof vi.fn>).mockReturnValue(mockSupabase)
+
+    const result = await getUpcoming1on1s('2026-05-23')
+    expect(result).toEqual([])
+  })
+
+  it('returns multiple meetings sorted by date', async () => {
+    const today = mockMeetingRow({ id: 'a', meeting_date: '2026-05-23' })
+    const tomorrow = mockMeetingRow({ id: 'b', meeting_date: '2026-05-24' })
+    const mockSupabase = makeMockSupabase([today, tomorrow])
+    ;(createClient as ReturnType<typeof vi.fn>).mockReturnValue(mockSupabase)
+
+    const result = await getUpcoming1on1s('2026-05-23')
+    expect(result).toHaveLength(2)
+    expect(result[0].id).toBe('a')
+    expect(result[1].id).toBe('b')
+  })
+
+  it('tomorrow date computed correctly at month boundary', async () => {
+    const mockSupabase = makeMockSupabase([])
+    ;(createClient as ReturnType<typeof vi.fn>).mockReturnValue(mockSupabase)
+
+    await getUpcoming1on1s('2026-05-31')
+
+    const chain = mockSupabase._chain
+    expect(chain.lte).toHaveBeenCalledWith('meeting_date', '2026-06-01')
+  })
+
+  it('throws on supabase error', async () => {
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      gte: vi.fn().mockReturnThis(),
+      lte: vi.fn().mockReturnThis(),
+      not: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+    }
+    const mockSupabase = { from: vi.fn().mockReturnValue(chain), auth: { getUser: vi.fn() } }
+    ;(createClient as ReturnType<typeof vi.fn>).mockReturnValue(mockSupabase)
+
+    await expect(getUpcoming1on1s('2026-05-23')).rejects.toMatchObject({ message: 'DB error' })
+  })
+
+  it('uses current date when today param is omitted', async () => {
+    const mockSupabase = makeMockSupabase([])
+    ;(createClient as ReturnType<typeof vi.fn>).mockReturnValue(mockSupabase)
+
+    await getUpcoming1on1s()
+
+    const chain = mockSupabase._chain
+    const today = new Date().toISOString().split('T')[0]
+    expect(chain.gte).toHaveBeenCalledWith('meeting_date', today)
+  })
+})

--- a/lib/services/__tests__/prep-brief.test.ts
+++ b/lib/services/__tests__/prep-brief.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for prep-brief service
+ * Mocks callAI and supabase — no live network calls.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { generatePrepBrief, getPrepBriefContext } from '../prep-brief'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/services/ai', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/services/ai')>()
+  return { ...actual, callAI: vi.fn() }
+})
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: vi.fn(),
+}))
+
+import { callAI } from '@/lib/services/ai'
+import { createClient } from '@/lib/supabase/client'
+const mockCallAI = vi.mocked(callAI)
+const mockCreateClient = vi.mocked(createClient)
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const PERSON_ROW = { id: 'person-1', full_name: 'Alice Chen', role: 'Senior Engineer', level: 'Senior' }
+
+const MEETINGS_ROWS = [
+  { title: '1:1 with Alice', meeting_date: '2026-05-16', notes: 'Discussed roadmap.', action_items: 'Alice to write spec.' },
+]
+
+const FOLLOW_UP_ROWS = [
+  { title: 'Check on promo timeline', created_at: '2026-05-01T00:00:00Z' },
+]
+
+const EVIDENCE_ROWS = [
+  { category: 'achievement', title: 'Led auth migration', occurred_at: '2026-05-10' },
+]
+
+const ASSESSMENT_ROWS = [
+  { assessed_level: 'Mid', competency_areas: { name: 'System Design' } },
+]
+
+function makeChain(resolvedValue: unknown) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {}
+  const methods = ['select', 'eq', 'gte', 'order', 'limit', 'single', 'not']
+  for (const m of methods) {
+    chain[m] = vi.fn().mockReturnValue(chain)
+  }
+  // Terminal resolution points: single (person), limit (all list queries)
+  chain['single'].mockResolvedValue(resolvedValue)
+  chain['limit'].mockResolvedValue(resolvedValue)
+  return chain
+}
+
+const TABLE_RESULTS: Record<string, unknown> = {
+  people:                   { data: PERSON_ROW, error: null },
+  meetings:                 { data: MEETINGS_ROWS, error: null },
+  follow_ups:               { data: FOLLOW_UP_ROWS, error: null },
+  evidence_entries:         { data: EVIDENCE_ROWS, error: null },
+  competency_assessments:   { data: ASSESSMENT_ROWS, error: null },
+}
+
+function makeSupabaseMock() {
+  const client = {
+    from: vi.fn().mockImplementation((table: string) => {
+      const result = TABLE_RESULTS[table] ?? { data: [], error: null }
+      return makeChain(result)
+    }),
+    auth: { getUser: vi.fn() },
+  }
+  return client
+}
+
+const AI_RESPONSE = {
+  content: '**Carry-over topics**\n- Check on promo timeline\n\n**Questions to ask**\n- How is the spec coming along?',
+  tokensUsed: { input: 400, output: 120 },
+  model: 'claude-sonnet-4-6',
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('getPrepBriefContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateClient.mockReturnValue(makeSupabaseMock() as unknown as ReturnType<typeof createClient>)
+  })
+
+  it('returns correct person name and role', async () => {
+    const ctx = await getPrepBriefContext('person-1')
+    expect(ctx.personName).toBe('Alice Chen')
+    expect(ctx.role).toBe('Senior Engineer')
+    expect(ctx.level).toBe('Senior')
+  })
+
+  it('maps meeting rows to camelCase shape', async () => {
+    const ctx = await getPrepBriefContext('person-1')
+    expect(ctx.recentMeetings[0].meetingDate).toBe('2026-05-16')
+    expect(ctx.recentMeetings[0].actionItems).toBe('Alice to write spec.')
+  })
+
+  it('maps follow-up rows correctly', async () => {
+    const ctx = await getPrepBriefContext('person-1')
+    expect(ctx.openFollowUps[0].title).toBe('Check on promo timeline')
+  })
+
+  it('maps evidence rows correctly', async () => {
+    const ctx = await getPrepBriefContext('person-1')
+    expect(ctx.recentEvidence[0].occurredAt).toBe('2026-05-10')
+    expect(ctx.recentEvidence[0].category).toBe('achievement')
+  })
+
+  it('includes competency gap when assessed level is below person level', async () => {
+    const ctx = await getPrepBriefContext('person-1')
+    // Alice is Senior, assessment is Mid → gap
+    expect(ctx.competencyGaps.some((g) => g.areaName === 'System Design')).toBe(true)
+  })
+})
+
+describe('generatePrepBrief', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateClient.mockReturnValue(makeSupabaseMock() as unknown as ReturnType<typeof createClient>)
+    mockCallAI.mockResolvedValue(AI_RESPONSE)
+  })
+
+  it('returns brief with personName, content, and generatedAt', async () => {
+    const brief = await generatePrepBrief('person-1')
+    expect(brief.personId).toBe('person-1')
+    expect(brief.personName).toBe('Alice Chen')
+    expect(brief.content).toContain('Carry-over topics')
+    expect(brief.generatedAt).toBeTruthy()
+  })
+
+  it('calls callAI with ONE_ON_ONE_PREP_SYSTEM', async () => {
+    await generatePrepBrief('person-1')
+    expect(mockCallAI).toHaveBeenCalledOnce()
+    const [req] = mockCallAI.mock.calls[0]
+    expect(req.systemPrompt).toContain('Carry-over topics')
+  })
+
+  it('user prompt includes person name', async () => {
+    await generatePrepBrief('person-1')
+    const [req] = mockCallAI.mock.calls[0]
+    expect(req.userPrompt).toContain('Alice Chen')
+  })
+
+  it('passes AbortSignal through to callAI', async () => {
+    const controller = new AbortController()
+    await generatePrepBrief('person-1', controller.signal)
+    const [, signal] = mockCallAI.mock.calls[0]
+    expect(signal).toBe(controller.signal)
+  })
+
+  it('propagates callAI errors', async () => {
+    mockCallAI.mockRejectedValue(new Error('AI unavailable'))
+    await expect(generatePrepBrief('person-1')).rejects.toThrow('AI unavailable')
+  })
+
+  it('generatedAt is a valid ISO timestamp', async () => {
+    const brief = await generatePrepBrief('person-1')
+    expect(() => new Date(brief.generatedAt).toISOString()).not.toThrow()
+  })
+})

--- a/lib/services/meetings.ts
+++ b/lib/services/meetings.ts
@@ -212,9 +212,10 @@ export async function getUpcoming1on1s(
 ): Promise<Meeting[]> {
   const supabase = createClient()
 
-  const tomorrow = new Date(today + 'T00:00:00')
-  tomorrow.setDate(tomorrow.getDate() + 1)
-  const tomorrowStr = tomorrow.toISOString().split('T')[0]
+  // Compute tomorrow using UTC to avoid timezone shifts
+  const todayUtc = new Date(today + 'T00:00:00Z')
+  todayUtc.setUTCDate(todayUtc.getUTCDate() + 1)
+  const tomorrowStr = todayUtc.toISOString().split('T')[0]
 
   const { data: meetings, error } = await supabase
     .from('meetings')

--- a/lib/services/meetings.ts
+++ b/lib/services/meetings.ts
@@ -202,3 +202,30 @@ export async function getMeetingsForTeam(teamId: string): Promise<Meeting[]> {
 
   return (meetings ?? []).map((m) => rowToMeeting(m as unknown as MeetingRow))
 }
+
+/**
+ * Get upcoming 1:1 meetings for the current user (today + tomorrow).
+ * Returns meetings sorted by date ascending.
+ */
+export async function getUpcoming1on1s(
+  today: string = new Date().toISOString().split('T')[0]
+): Promise<Meeting[]> {
+  const supabase = createClient()
+
+  const tomorrow = new Date(today + 'T00:00:00')
+  tomorrow.setDate(tomorrow.getDate() + 1)
+  const tomorrowStr = tomorrow.toISOString().split('T')[0]
+
+  const { data: meetings, error } = await supabase
+    .from('meetings')
+    .select(MEETING_SELECT)
+    .eq('meeting_type', '1:1')
+    .gte('meeting_date', today)
+    .lte('meeting_date', tomorrowStr)
+    .not('person_id', 'is', null)
+    .order('meeting_date', { ascending: true })
+
+  if (error) throw error
+
+  return (meetings ?? []).map((m) => rowToMeeting(m as unknown as MeetingRow))
+}

--- a/lib/services/prep-brief.ts
+++ b/lib/services/prep-brief.ts
@@ -78,7 +78,7 @@ export async function getPrepBriefContext(personId: string): Promise<PrepBriefCo
         .order('occurred_at', { ascending: false })
         .limit(8),
 
-      // Competency gaps (assessed < expected)
+      // Competency gaps (assessed < expected) — limit to 20 most recent assessments
       supabase
         .from('competency_assessments')
         .select(`
@@ -86,7 +86,8 @@ export async function getPrepBriefContext(personId: string): Promise<PrepBriefCo
           competency_areas!inner(name)
         `)
         .eq('person_id', personId)
-        .order('assessed_at', { ascending: false }),
+        .order('assessed_at', { ascending: false })
+        .limit(20),
     ])
 
   if (personResult.error) throw personResult.error

--- a/lib/services/prep-brief.ts
+++ b/lib/services/prep-brief.ts
@@ -1,0 +1,192 @@
+/**
+ * Prep Brief Service
+ * Loads all context needed to generate a 1:1 prep brief for a person,
+ * then calls AI using the existing ONE_ON_ONE_PREP_SYSTEM prompt.
+ */
+
+import { createClient } from '@/lib/supabase/client'
+import { callAI } from '@/lib/services/ai'
+import { ONE_ON_ONE_PREP_SYSTEM, buildOneonOnePrepPrompt } from '@/lib/ai/prompts'
+
+export interface PrepBriefContext {
+  personId: string
+  personName: string
+  role: string | null
+  level: string | null
+  recentMeetings: Array<{
+    title: string
+    meetingDate: string
+    notes?: string | null
+    actionItems?: string | null
+  }>
+  openFollowUps: Array<{ title: string; createdAt: string }>
+  recentEvidence: Array<{ category: string; title: string; occurredAt: string }>
+  competencyGaps: Array<{ areaName: string; assessedLevel: string; expectedLevel: string }>
+}
+
+export interface PrepBrief {
+  personId: string
+  personName: string
+  content: string
+  generatedAt: string
+}
+
+/**
+ * Load all raw context for a person needed to build a 1:1 prep brief.
+ * Runs all queries in parallel.
+ */
+export async function getPrepBriefContext(personId: string): Promise<PrepBriefContext> {
+  const supabase = createClient()
+
+  const thirtyDaysAgo = new Date()
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+  const thirtyDaysAgoStr = thirtyDaysAgo.toISOString().split('T')[0]
+
+  const [personResult, meetingsResult, followUpsResult, evidenceResult, assessmentsResult] =
+    await Promise.all([
+      // Person details
+      supabase
+        .from('people')
+        .select('id, full_name, role, level')
+        .eq('id', personId)
+        .single(),
+
+      // Last 3 1:1 meetings with notes
+      supabase
+        .from('meetings')
+        .select('title, meeting_date, notes, action_items')
+        .eq('person_id', personId)
+        .eq('meeting_type', '1:1')
+        .order('meeting_date', { ascending: false })
+        .limit(3),
+
+      // Open follow-ups for this person
+      supabase
+        .from('follow_ups')
+        .select('title, created_at')
+        .eq('person_id', personId)
+        .eq('status', 'open')
+        .order('created_at', { ascending: true })
+        .limit(5),
+
+      // Recent evidence (last 30 days)
+      supabase
+        .from('evidence_entries')
+        .select('category, title, occurred_at')
+        .eq('person_id', personId)
+        .gte('occurred_at', thirtyDaysAgoStr)
+        .order('occurred_at', { ascending: false })
+        .limit(8),
+
+      // Competency gaps (assessed < expected)
+      supabase
+        .from('competency_assessments')
+        .select(`
+          assessed_level,
+          competency_areas!inner(name)
+        `)
+        .eq('person_id', personId)
+        .order('assessed_at', { ascending: false }),
+    ])
+
+  if (personResult.error) throw personResult.error
+
+  const person = personResult.data as {
+    id: string; full_name: string; role: string | null; level: string | null
+  }
+
+  const meetings = (meetingsResult.data ?? []).map((m: {
+    title: string; meeting_date: string; notes: string | null; action_items: string | null
+  }) => ({
+    title: m.title,
+    meetingDate: m.meeting_date,
+    notes: m.notes,
+    actionItems: m.action_items,
+  }))
+
+  const followUps = (followUpsResult.data ?? []).map((f: {
+    title: string; created_at: string
+  }) => ({
+    title: f.title,
+    createdAt: f.created_at,
+  }))
+
+  const evidence = (evidenceResult.data ?? []).map((e: {
+    category: string; title: string; occurred_at: string
+  }) => ({
+    category: e.category,
+    title: e.title,
+    occurredAt: e.occurred_at,
+  }))
+
+  // Resolve competency gaps: only include where person's level < their expected level
+  // We use the person's level as the "expected" baseline from the people record
+  const LEVEL_ORDER = ['Junior', 'Mid', 'Senior', 'Staff', 'Principal']
+  const personLevelIdx = person.level ? LEVEL_ORDER.indexOf(person.level) : -1
+
+  const competencyGaps = (assessmentsResult.data ?? [])
+    .map((a: { assessed_level: string; competency_areas: { name: string } | { name: string }[] | null }) => {
+      const areaName = Array.isArray(a.competency_areas)
+        ? a.competency_areas[0]?.name ?? 'Unknown'
+        : (a.competency_areas as { name: string } | null)?.name ?? 'Unknown'
+      return {
+        areaName,
+        assessedLevel: a.assessed_level,
+        expectedLevel: person.level ?? 'Senior',
+      }
+    })
+    .filter((g: { areaName: string; assessedLevel: string; expectedLevel: string }) => {
+      const assessedIdx = LEVEL_ORDER.indexOf(g.assessedLevel)
+      return personLevelIdx !== -1 && assessedIdx !== -1 && assessedIdx < personLevelIdx
+    })
+    .slice(0, 5)
+
+  return {
+    personId: person.id,
+    personName: person.full_name,
+    role: person.role,
+    level: person.level,
+    recentMeetings: meetings,
+    openFollowUps: followUps,
+    recentEvidence: evidence,
+    competencyGaps,
+  }
+}
+
+/**
+ * Generate a 1:1 prep brief for a person using the existing prompt infrastructure.
+ * Returns the generated markdown content.
+ */
+export async function generatePrepBrief(
+  personId: string,
+  signal?: AbortSignal
+): Promise<PrepBrief> {
+  const context = await getPrepBriefContext(personId)
+
+  const userPrompt = buildOneonOnePrepPrompt({
+    name: context.personName,
+    role: context.role,
+    level: context.level,
+    recentMeetings: context.recentMeetings,
+    openFollowUps: context.openFollowUps,
+    recentEvidence: context.recentEvidence,
+    competencyGaps: context.competencyGaps,
+  })
+
+  const response = await callAI(
+    {
+      systemPrompt: ONE_ON_ONE_PREP_SYSTEM,
+      userPrompt,
+      maxTokens: 600,
+      temperature: 0.3,
+    },
+    signal
+  )
+
+  return {
+    personId,
+    personName: context.personName,
+    content: response.content,
+    generatedAt: new Date().toISOString(),
+  }
+}


### PR DESCRIPTION
## Summary

Implements [#101](https://github.com/shiphrahx/Caliber/issues/101) — upcoming 1:1s are auto-detected on dashboard load and a prep brief can be generated per meeting in one click. Uses the existing `ONE_ON_ONE_PREP_SYSTEM` prompt and data already stored in the system.

## Changes

### `lib/services/meetings.ts`
- `getUpcoming1on1s(today?)` — queries 1:1 meetings for today and tomorrow with a linked person. UTC-safe date arithmetic for tomorrow boundary. Returns sorted ascending by date.

### `lib/services/prep-brief.ts` (new)
- `getPrepBriefContext(personId)` — parallel-fetches all context for a person: last 3 1:1 meeting notes, open follow-ups (≤5), recent evidence last 30 days (≤8), competency gaps vs person's level (≤5), person details
- `generatePrepBrief(personId, signal?)` — builds prompt via `buildOneonOnePrepPrompt`, calls AI with `ONE_ON_ONE_PREP_SYSTEM`, returns `PrepBrief` with content and `generatedAt`
- AbortSignal passed through for cancel support

### `components/dashboard/upcoming-one-on-ones.tsx` (new)
- **`UpcomingOneOnOnes`** widget — loads on mount, renders nothing when no upcoming 1:1s (zero noise for managers with a clear calendar)
- **`PrepCard`** — per-meeting card showing person name, date chip (Today/Tomorrow), link to person page
- "Prep brief" button → generates brief, auto-expands; click again to hide/show
- "Regenerate" link in footer to refresh the brief
- Cancel in-flight request by clicking button while loading

### `app/(dashboard)/dashboard/page.tsx`
- Added `<UpcomingOneOnOnes />` between the weekly review banner and the widgets row

## Test Results
- 372 total tests, 370 passing (2 pre-existing date-label failures in `task-card.test.tsx`)
- **8 new tests** — `getUpcoming1on1s`: UTC date arithmetic, filter correctness, error handling, default param
- **11 new tests** — `generatePrepBrief` / `getPrepBriefContext`: context mapping, gap detection, prompt content, AbortSignal, error propagation

## Closes
Closes #101

---