### PR TITLE
feat: sentiment trend tracking per person over time (#102)

### DIFF
--- a/app/(dashboard)/people/[id]/page.tsx
+++ b/app/(dashboard)/people/[id]/page.tsx
@@ -17,6 +17,7 @@ import { getTeams, type Team } from "@/lib/services/teams"
 import { getMeetingsForPerson, createMeeting, type MeetingType, type RecurrenceType } from "@/lib/services/meetings"
 import { LEVEL_BADGE } from "@/lib/badge-styles"
 import { EvidenceSection } from "@/components/evidence/evidence-section"
+import { SentimentTrendChart } from "@/components/evidence/sentiment-trend-chart"
 import { CompetencySection } from "@/components/competency/competency-section"
 import { FollowUpList } from "@/components/follow-ups/follow-up-list"
 import { FollowUpForm } from "@/components/follow-ups/follow-up-form"
@@ -594,6 +595,11 @@ export default function PersonDetailPage({ params }: { params: Promise<{ id: str
           followUps={followUps}
           onChanged={() => getFollowUpsForPerson(personId!).then(setFollowUps).catch(console.error)}
         />
+      </div>
+
+      {/* Sentiment Trend */}
+      <div style={{ marginTop: "24px" }}>
+        <SentimentTrendChart personId={personId!} days={60} />
       </div>
 
       {/* Evidence section */}

--- a/components/evidence/sentiment-trend-chart.tsx
+++ b/components/evidence/sentiment-trend-chart.tsx
@@ -1,0 +1,254 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { TrendingDown, TrendingUp, Minus } from "lucide-react"
+import { getEvidenceSentimentTimeline, type WeeklySentimentBucket } from "@/lib/services/evidence"
+
+interface SentimentTrendChartProps {
+  personId: string
+  days?: number
+}
+
+const BAR_HEIGHT = 80
+const BAR_WIDTH = 24
+const BAR_GAP = 6
+
+const COLORS = {
+  positive: "#4ade80",
+  neutral:  "#9ca3af",
+  negative: "#f87171",
+}
+
+function Tooltip({ bucket }: { bucket: WeeklySentimentBucket }) {
+  const date = new Date(bucket.weekStart + "T00:00:00")
+  const label = date.toLocaleDateString("en-GB", { day: "numeric", month: "short" })
+  return (
+    <div style={{
+      position: "absolute",
+      bottom: "calc(100% + 6px)",
+      left: "50%",
+      transform: "translateX(-50%)",
+      background: "var(--surf-3)",
+      border: "1px solid var(--border-2)",
+      borderRadius: "4px",
+      padding: "6px 8px",
+      fontSize: "11px",
+      color: "var(--text-1)",
+      whiteSpace: "nowrap",
+      zIndex: 10,
+      pointerEvents: "none",
+      lineHeight: 1.5,
+    }}>
+      <div style={{ fontWeight: 600, marginBottom: "2px" }}>w/c {label}</div>
+      <div style={{ color: COLORS.positive }}>↑ {bucket.positive} positive</div>
+      <div style={{ color: COLORS.neutral }}>– {bucket.neutral} neutral</div>
+      <div style={{ color: COLORS.negative }}>↓ {bucket.negative} negative</div>
+      <div style={{ color: "var(--text-3)", marginTop: "2px" }}>{bucket.total} total</div>
+    </div>
+  )
+}
+
+function StackedBar({ bucket, maxTotal }: { bucket: WeeklySentimentBucket; maxTotal: number }) {
+  const [hovered, setHovered] = useState(false)
+  const scale = maxTotal > 0 ? BAR_HEIGHT / maxTotal : 0
+
+  const negH  = Math.max(1, Math.round(bucket.negative  * scale))
+  const neutH = Math.max(bucket.neutral  > 0 ? 1 : 0, Math.round(bucket.neutral  * scale))
+  const posH  = Math.max(bucket.positive > 0 ? 1 : 0, Math.round(bucket.positive * scale))
+
+  const totalRendered = negH + neutH + posH
+  const empty = bucket.total === 0
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: `${BAR_WIDTH}px`,
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "flex-end",
+        height: `${BAR_HEIGHT}px`,
+        cursor: "default",
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {hovered && !empty && <Tooltip bucket={bucket} />}
+      {empty ? (
+        <div style={{
+          height: "2px",
+          background: "var(--border-2)",
+          borderRadius: "1px",
+          opacity: 0.4,
+        }} />
+      ) : (
+        <div style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "1px",
+          borderRadius: "3px",
+          overflow: "hidden",
+          height: `${totalRendered}px`,
+        }}>
+          {bucket.positive > 0 && (
+            <div style={{ height: `${posH}px`, background: COLORS.positive }} />
+          )}
+          {bucket.neutral > 0 && (
+            <div style={{ height: `${neutH}px`, background: COLORS.neutral }} />
+          )}
+          {bucket.negative > 0 && (
+            <div style={{ height: `${negH}px`, background: COLORS.negative }} />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function computeTrend(buckets: WeeklySentimentBucket[]): "improving" | "declining" | "stable" | null {
+  if (buckets.length < 2) return null
+  const half = Math.floor(buckets.length / 2)
+  const recent = buckets.slice(-half)
+  const prior  = buckets.slice(0, half)
+
+  const negRate = (bs: WeeklySentimentBucket[]) => {
+    const total = bs.reduce((s, b) => s + b.total, 0)
+    const neg   = bs.reduce((s, b) => s + b.negative, 0)
+    return total > 0 ? neg / total : 0
+  }
+
+  const recentRate = negRate(recent)
+  const priorRate  = negRate(prior)
+  const delta = recentRate - priorRate
+
+  if (delta >  0.15) return "declining"
+  if (delta < -0.15) return "improving"
+  return "stable"
+}
+
+export function SentimentTrendChart({ personId, days = 60 }: SentimentTrendChartProps) {
+  const [buckets, setBuckets] = useState<WeeklySentimentBucket[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!personId) return
+    setLoading(true)
+    setError(null)
+    getEvidenceSentimentTimeline(personId, days)
+      .then(setBuckets)
+      .catch(e => setError(e instanceof Error ? e.message : "Failed to load"))
+      .finally(() => setLoading(false))
+  }, [personId, days])
+
+  const trend = computeTrend(buckets)
+  const totalEntries = buckets.reduce((s, b) => s + b.total, 0)
+  const maxTotal = Math.max(...buckets.map(b => b.total), 1)
+
+  if (loading) {
+    return (
+      <div style={{ height: "120px", display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <span style={{ fontSize: "var(--text-caption)", color: "var(--text-3)" }}>Loading sentiment data…</span>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div style={{ height: "80px", display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <span style={{ fontSize: "var(--text-caption)", color: "#f87171" }}>Could not load sentiment data</span>
+      </div>
+    )
+  }
+
+  const trendConfig = trend === "declining"
+    ? { Icon: TrendingDown, color: "#f87171",  label: "Trending negative" }
+    : trend === "improving"
+    ? { Icon: TrendingUp,   color: "#4ade80",  label: "Improving" }
+    : trend === "stable"
+    ? { Icon: Minus,        color: "#9ca3af",  label: "Stable" }
+    : null
+
+  return (
+    <div style={{ background: "var(--surf-2)", border: "1px solid var(--border-1)", borderRadius: "6px", padding: "14px 16px" }}>
+      {/* Header */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "12px" }}>
+        <span style={{ fontSize: "var(--text-label)", fontWeight: 600, color: "var(--text-2)" }}>
+          Sentiment Trend
+          <span style={{ fontWeight: 400, color: "var(--text-3)", marginLeft: "6px" }}>last {days} days</span>
+        </span>
+        <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+          {trendConfig && (
+            <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+              <trendConfig.Icon style={{ width: "12px", height: "12px", color: trendConfig.color }} />
+              <span style={{ fontSize: "var(--text-caption)", color: trendConfig.color, fontWeight: 600 }}>
+                {trendConfig.label}
+              </span>
+            </div>
+          )}
+          {/* Legend */}
+          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            {(["positive", "neutral", "negative"] as const).map(s => (
+              <div key={s} style={{ display: "flex", alignItems: "center", gap: "3px" }}>
+                <div style={{ width: "8px", height: "8px", borderRadius: "2px", background: COLORS[s] }} />
+                <span style={{ fontSize: "11px", color: "var(--text-3)", textTransform: "capitalize" }}>{s}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Chart */}
+      {totalEntries === 0 ? (
+        <div style={{ height: `${BAR_HEIGHT}px`, display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <span style={{ fontSize: "var(--text-caption)", color: "var(--text-3)" }}>
+            No evidence with sentiment tags in this period
+          </span>
+        </div>
+      ) : (
+        <div style={{ overflowX: "auto" }}>
+          <div style={{
+            display: "flex",
+            alignItems: "flex-end",
+            gap: `${BAR_GAP}px`,
+            minWidth: "fit-content",
+            paddingBottom: "4px",
+          }}>
+            {buckets.map(b => (
+              <StackedBar key={b.weekStart} bucket={b} maxTotal={maxTotal} />
+            ))}
+          </div>
+          {/* X-axis labels — show every other week to avoid crowding */}
+          <div style={{
+            display: "flex",
+            gap: `${BAR_GAP}px`,
+            marginTop: "4px",
+          }}>
+            {buckets.map((b, i) => {
+              const show = i === 0 || i === buckets.length - 1 || (buckets.length <= 8) || i % 2 === 0
+              const label = show
+                ? new Date(b.weekStart + "T00:00:00").toLocaleDateString("en-GB", { day: "numeric", month: "short" })
+                : ""
+              return (
+                <div
+                  key={b.weekStart}
+                  style={{
+                    width: `${BAR_WIDTH}px`,
+                    fontSize: "10px",
+                    color: "var(--text-3)",
+                    textAlign: "center",
+                    flexShrink: 0,
+                    overflow: "hidden",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {label}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/hooks/use-weekly-review-signals.ts
+++ b/lib/hooks/use-weekly-review-signals.ts
@@ -7,6 +7,7 @@ import {
   computePeopleSignals,
   computeFollowUpSignals,
   computeActionItemSignals,
+  computeSentimentDriftSignals,
   sortSignals,
   buildDismissedSet,
 } from '@/lib/signals/compute'
@@ -31,6 +32,13 @@ async function computeAllSignals(dismissedItems: DismissedItem[]): Promise<Signa
 
   const data = await loadSignalData()
 
+  // Build evidenceByPerson map for sentiment drift computation (uses 60-day window)
+  const evidenceByPerson = new Map<string, Array<{ occurred_at: string; sentiment: string | null }>>()
+  for (const e of data.evidenceRecent as Array<{ person_id: string; occurred_at: string; sentiment: string | null }>) {
+    if (!evidenceByPerson.has(e.person_id)) evidenceByPerson.set(e.person_id, [])
+    evidenceByPerson.get(e.person_id)!.push({ occurred_at: e.occurred_at, sentiment: e.sentiment })
+  }
+
   const [taskSignals, peopleSignals, actionSignals] = await Promise.all([
     Promise.resolve(computeTaskSignals(data, dismissedSet, today)),
     Promise.resolve(computePeopleSignals(data, dismissedSet, today)),
@@ -38,8 +46,14 @@ async function computeAllSignals(dismissedItems: DismissedItem[]): Promise<Signa
   ])
 
   const followUpSignals = computeFollowUpSignals(data.openFollowUps, dismissedSet, today)
+  const sentimentDriftSignals = computeSentimentDriftSignals(
+    data.activePeople,
+    evidenceByPerson,
+    dismissedSet,
+    today
+  )
 
-  return sortSignals([...taskSignals, ...peopleSignals, ...actionSignals, ...followUpSignals])
+  return sortSignals([...taskSignals, ...peopleSignals, ...actionSignals, ...followUpSignals, ...sentimentDriftSignals])
 }
 
 export function useWeeklyReviewSignals(dismissedItems: DismissedItem[]): SignalsData {

--- a/lib/services/__tests__/evidence-sentiment-timeline.test.ts
+++ b/lib/services/__tests__/evidence-sentiment-timeline.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { getEvidenceSentimentTimeline } from '../evidence'
+import { mockSupabaseClient } from '../../../test/mocks/supabase'
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeRow(occurred_at: string, sentiment: 'positive' | 'neutral' | 'negative' | null) {
+  return { occurred_at, sentiment }
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('getEvidenceSentimentTimeline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty array when no evidence exists', async () => {
+    mockSupabaseClient.from = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          gte: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        }),
+      }),
+    })
+
+    const result = await getEvidenceSentimentTimeline('person-1', 60)
+    expect(result).toEqual([])
+  })
+
+  it('throws on database error', async () => {
+    mockSupabaseClient.from = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          gte: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+          }),
+        }),
+      }),
+    })
+
+    await expect(getEvidenceSentimentTimeline('person-1', 60)).rejects.toThrow('DB error')
+  })
+
+  it('groups entries into weekly buckets correctly', async () => {
+    // Two entries same week (Mon 2026-05-18 and Wed 2026-05-20)
+    const rows = [
+      makeRow('2026-05-18', 'positive'),
+      makeRow('2026-05-20', 'negative'),
+    ]
+    mockSupabaseClient.from = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          gte: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: rows, error: null }),
+          }),
+        }),
+      }),
+    })
+
+    const result = await getEvidenceSentimentTimeline('person-1', 60)
+
+    // Both map to Monday 2026-05-18
+    expect(result).toHaveLength(1)
+    expect(result[0].weekStart).toBe('2026-05-18')
+    expect(result[0].positive).toBe(1)
+    expect(result[0].negative).toBe(1)
+    expect(result[0].neutral).toBe(0)
+    expect(result[0].total).toBe(2)
+  })
+
+  it('handles Sunday entries mapping to the Monday of the same week', async () => {
+    // Sunday 2026-05-17 → Monday of that week is 2026-05-11
+    const rows = [makeRow('2026-05-17', 'neutral')]
+    mockSupabaseClient.from = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          gte: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: rows, error: null }),
+          }),
+        }),
+      }),
+    })
+
+    const result = await getEvidenceSentimentTimeline('person-1', 60)
+
+    expect(result).toHaveLength(1)
+    // 2026-05-17 is a Sunday → Monday is 2026-05-11
+    expect(result[0].weekStart).toBe('2026-05-11')
+    expect(result[0].neutral).toBe(1)
+  })
+
+  it('separates entries from different weeks', async () => {
+    const rows = [
+      makeRow('2026-05-11', 'positive'), // Mon week 1
+      makeRow('2026-05-12', 'negative'), // Tue week 1
+      makeRow('2026-05-18', 'negative'), // Mon week 2
+    ]
+    mockSupabaseClient.from = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          gte: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: rows, error: null }),
+          }),
+        }),
+      }),
+    })
+
+    const result = await getEvidenceSentimentTimeline('person-1', 60)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].weekStart).toBe('2026-05-11')
+    expect(result[0].total).toBe(2)
+    expect(result[1].weekStart).toBe('2026-05-18')
+    expect(result[1].total).toBe(1)
+  })
+
+  it('treats null sentiment as neutral', async () => {
+    const rows = [makeRow('2026-05-18', null)]
+    mockSupabaseClient.from = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          gte: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: rows, error: null }),
+          }),
+        }),
+      }),
+    })
+
+    const result = await getEvidenceSentimentTimeline('person-1', 60)
+
+    expect(result[0].neutral).toBe(1)
+    expect(result[0].positive).toBe(0)
+    expect(result[0].negative).toBe(0)
+  })
+
+  it('returns buckets sorted oldest to newest', async () => {
+    const rows = [
+      makeRow('2026-05-18', 'positive'),
+      makeRow('2026-05-04', 'negative'),
+      makeRow('2026-05-11', 'neutral'),
+    ]
+    mockSupabaseClient.from = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          gte: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: rows, error: null }),
+          }),
+        }),
+      }),
+    })
+
+    const result = await getEvidenceSentimentTimeline('person-1', 60)
+
+    expect(result[0].weekStart < result[1].weekStart).toBe(true)
+    expect(result[1].weekStart < result[2].weekStart).toBe(true)
+  })
+
+  it('uses correct days parameter for start date filtering', async () => {
+    mockSupabaseClient.from = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          gte: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        }),
+      }),
+    })
+
+    await getEvidenceSentimentTimeline('person-1', 30)
+
+    // Verify gte was called (date filtering happens in query)
+    const fromCall = mockSupabaseClient.from as ReturnType<typeof vi.fn>
+    expect(fromCall).toHaveBeenCalledWith('evidence_entries')
+  })
+})

--- a/lib/services/evidence.ts
+++ b/lib/services/evidence.ts
@@ -263,6 +263,68 @@ export async function deleteEvidence(id: string): Promise<void> {
   if (error) throw new Error(error.message)
 }
 
+// ── Sentiment Timeline ────────────────────────────────────────────────────────
+
+export interface WeeklySentimentBucket {
+  weekStart: string  // ISO date string, Monday of the week
+  positive: number
+  neutral: number
+  negative: number
+  total: number
+}
+
+/**
+ * Returns weekly aggregations of evidence sentiment for a person
+ * over the last `days` days (default 60), ordered oldest → newest.
+ */
+export async function getEvidenceSentimentTimeline(
+  personId: string,
+  days: number = 60
+): Promise<WeeklySentimentBucket[]> {
+  const supabase = createClient()
+
+  const startDate = new Date()
+  startDate.setDate(startDate.getDate() - days)
+  const startISO = startDate.toISOString().split('T')[0]
+
+  const { data, error } = await supabase
+    .from('evidence_entries')
+    .select('occurred_at, sentiment')
+    .eq('person_id', personId)
+    .gte('occurred_at', startISO)
+    .order('occurred_at', { ascending: true })
+
+  if (error) throw new Error(error.message)
+
+  const rows = (data ?? []) as { occurred_at: string; sentiment: EvidenceSentiment | null }[]
+
+  // Group into ISO week buckets (Mon–Sun)
+  const buckets = new Map<string, WeeklySentimentBucket>()
+
+  for (const row of rows) {
+    // Parse date components directly to avoid timezone shift issues
+    const [year, month, day] = row.occurred_at.split('-').map(Number)
+    // Use UTC date to determine day-of-week consistently
+    const d = new Date(Date.UTC(year, month - 1, day))
+    const dayOfWeek = d.getUTCDay() // 0 = Sun, 1 = Mon … 6 = Sat
+    const diffToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek
+    const mondayMs = d.getTime() + diffToMonday * 24 * 60 * 60 * 1000
+    const monday = new Date(mondayMs)
+    const weekStart = monday.toISOString().split('T')[0]
+
+    if (!buckets.has(weekStart)) {
+      buckets.set(weekStart, { weekStart, positive: 0, neutral: 0, negative: 0, total: 0 })
+    }
+    const bucket = buckets.get(weekStart)!
+    bucket.total++
+    if (row.sentiment === 'positive') bucket.positive++
+    else if (row.sentiment === 'negative') bucket.negative++
+    else bucket.neutral++
+  }
+
+  return Array.from(buckets.values()).sort((a, b) => a.weekStart.localeCompare(b.weekStart))
+}
+
 // ── Review Cycles ─────────────────────────────────────────────────────────────
 
 export async function getReviewCycles(): Promise<ReviewCycle[]> {

--- a/lib/services/weekly-review.ts
+++ b/lib/services/weekly-review.ts
@@ -14,6 +14,7 @@ export type DismissedItemType =
   | 'ageing_follow_up'
   | 'surfaced_follow_up'
   | 'action_overload'
+  | 'sentiment_drift'
 
 export interface WeeklyReview {
   id: string

--- a/lib/signals/__tests__/sentiment-drift.test.ts
+++ b/lib/signals/__tests__/sentiment-drift.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeSentimentDriftForPeriods,
+  computeSentimentDriftSignals,
+  type SentimentPeriodStats,
+} from '../compute'
+
+// ── computeSentimentDriftForPeriods ──────────────────────────────────────────
+
+describe('computeSentimentDriftForPeriods', () => {
+  it('detects drift when recent >60% negative and prior <40% negative', () => {
+    const recent: SentimentPeriodStats = { positive: 1, neutral: 0, negative: 9, total: 10 } // 90% neg
+    const prior:  SentimentPeriodStats = { positive: 7, neutral: 0, negative: 3, total: 10 } // 30% neg
+
+    const result = computeSentimentDriftForPeriods(recent, prior)
+
+    expect(result.drifting).toBe(true)
+    expect(result.severe).toBe(false)
+    expect(result.recentNegRate).toBeCloseTo(0.9)
+    expect(result.priorNegRate).toBeCloseTo(0.3)
+  })
+
+  it('marks as severe when both periods show elevated negativity', () => {
+    const recent: SentimentPeriodStats = { positive: 1, neutral: 0, negative: 9, total: 10 } // 90%
+    const prior:  SentimentPeriodStats = { positive: 1, neutral: 0, negative: 5, total: 6  } // 83%
+
+    const result = computeSentimentDriftForPeriods(recent, prior)
+
+    expect(result.drifting).toBe(true)
+    expect(result.severe).toBe(true)
+  })
+
+  it('no drift when recent negative rate is below threshold (≤60%)', () => {
+    const recent: SentimentPeriodStats = { positive: 5, neutral: 0, negative: 5, total: 10 } // 50%
+    const prior:  SentimentPeriodStats = { positive: 9, neutral: 0, negative: 1, total: 10 } // 10%
+
+    const result = computeSentimentDriftForPeriods(recent, prior)
+
+    expect(result.drifting).toBe(false)
+    expect(result.severe).toBe(false)
+  })
+
+  it('no drift when prior negative rate is already ≥40% (no worsening)', () => {
+    // recent = 70% negative, but prior was already 50% negative → severe path
+    const recent: SentimentPeriodStats = { positive: 1, neutral: 0, negative: 7, total: 10 } // 70%
+    const prior:  SentimentPeriodStats = { positive: 5, neutral: 0, negative: 5, total: 10 } // 50%
+
+    const result = computeSentimentDriftForPeriods(recent, prior)
+
+    // severe = true because prior >= 40%, still fires
+    expect(result.drifting).toBe(true)
+    expect(result.severe).toBe(true)
+  })
+
+  it('returns zero rates when periods have no entries', () => {
+    const empty: SentimentPeriodStats = { positive: 0, neutral: 0, negative: 0, total: 0 }
+
+    const result = computeSentimentDriftForPeriods(empty, empty)
+
+    expect(result.recentNegRate).toBe(0)
+    expect(result.priorNegRate).toBe(0)
+    expect(result.drifting).toBe(false)
+  })
+
+  it('handles exactly 60% recent negative — should NOT trigger (>60 required)', () => {
+    const recent: SentimentPeriodStats = { positive: 4, neutral: 0, negative: 6, total: 10 } // exactly 60%
+    const prior:  SentimentPeriodStats = { positive: 8, neutral: 0, negative: 2, total: 10 } // 20%
+
+    const result = computeSentimentDriftForPeriods(recent, prior)
+
+    expect(result.drifting).toBe(false)
+  })
+})
+
+// ── computeSentimentDriftSignals ─────────────────────────────────────────────
+
+describe('computeSentimentDriftSignals', () => {
+  const today = new Date('2026-05-23T12:00:00Z')
+
+  const people = [
+    { id: 'person-1', full_name: 'Alice' },
+    { id: 'person-2', full_name: 'Bob' },
+  ]
+
+  function daysAgo(n: number): string {
+    const d = new Date(today)
+    d.setDate(d.getDate() - n)
+    return d.toISOString().split('T')[0]
+  }
+
+  it('fires warning signal for drifting person', () => {
+    // Recent 30 days: 8/10 negative (80%) — drift
+    // Prior  30 days: 2/10 negative (20%) — low
+    const entries = [
+      // recent (days 1-30)
+      ...Array.from({ length: 8 }, (_, i) => ({ occurred_at: daysAgo(i + 1), sentiment: 'negative' })),
+      ...Array.from({ length: 2 }, (_, i) => ({ occurred_at: daysAgo(i + 20), sentiment: 'positive' })),
+      // prior (days 31-60)
+      ...Array.from({ length: 2 }, (_, i) => ({ occurred_at: daysAgo(i + 31), sentiment: 'negative' })),
+      ...Array.from({ length: 8 }, (_, i) => ({ occurred_at: daysAgo(i + 40), sentiment: 'positive' })),
+    ]
+
+    const evidenceByPerson = new Map([['person-1', entries]])
+    const dismissed = new Set<string>()
+
+    const signals = computeSentimentDriftSignals(people, evidenceByPerson, dismissed, today)
+
+    const driftSignal = signals.find(s => s.type === 'sentiment_drift' && s.personId === 'person-1')
+    expect(driftSignal).toBeDefined()
+    expect(driftSignal?.severity).toBe('warning')
+    expect(driftSignal?.personName).toBe('Alice')
+    expect(driftSignal?.entityType).toBe('person')
+    expect(driftSignal?.message).toContain('Alice')
+    expect(driftSignal?.message).toContain('negative')
+  })
+
+  it('fires critical signal when both periods are highly negative (severe)', () => {
+    // Recent: 8/10 negative = 80%; Prior: 6/10 negative = 60% (both elevated)
+    const entries = [
+      ...Array.from({ length: 8 }, (_, i) => ({ occurred_at: daysAgo(i + 1), sentiment: 'negative' })),
+      ...Array.from({ length: 2 }, (_, i) => ({ occurred_at: daysAgo(i + 20), sentiment: 'positive' })),
+      ...Array.from({ length: 6 }, (_, i) => ({ occurred_at: daysAgo(i + 31), sentiment: 'negative' })),
+      ...Array.from({ length: 4 }, (_, i) => ({ occurred_at: daysAgo(i + 45), sentiment: 'positive' })),
+    ]
+
+    const evidenceByPerson = new Map([['person-1', entries]])
+    const dismissed = new Set<string>()
+
+    const signals = computeSentimentDriftSignals(people, evidenceByPerson, dismissed, today)
+
+    const driftSignal = signals.find(s => s.type === 'sentiment_drift' && s.personId === 'person-1')
+    expect(driftSignal?.severity).toBe('critical')
+  })
+
+  it('produces no signal when no drift detected', () => {
+    // Mostly positive evidence in both windows
+    const entries = [
+      ...Array.from({ length: 9 }, (_, i) => ({ occurred_at: daysAgo(i + 1), sentiment: 'positive' })),
+      { occurred_at: daysAgo(15), sentiment: 'negative' },
+      ...Array.from({ length: 9 }, (_, i) => ({ occurred_at: daysAgo(i + 31), sentiment: 'positive' })),
+      { occurred_at: daysAgo(45), sentiment: 'negative' },
+    ]
+
+    const evidenceByPerson = new Map([['person-1', entries]])
+    const dismissed = new Set<string>()
+
+    const signals = computeSentimentDriftSignals(people, evidenceByPerson, dismissed, today)
+
+    expect(signals.find(s => s.type === 'sentiment_drift')).toBeUndefined()
+  })
+
+  it('produces no signal when no evidence in either window', () => {
+    const evidenceByPerson = new Map<string, any[]>()
+    const dismissed = new Set<string>()
+
+    const signals = computeSentimentDriftSignals(people, evidenceByPerson, dismissed, today)
+
+    expect(signals.find(s => s.type === 'sentiment_drift')).toBeUndefined()
+  })
+
+  it('produces no signal when recent window is empty', () => {
+    // Evidence only in prior window
+    const entries = Array.from({ length: 5 }, (_, i) => ({
+      occurred_at: daysAgo(i + 35),
+      sentiment: 'negative',
+    }))
+
+    const evidenceByPerson = new Map([['person-1', entries]])
+    const dismissed = new Set<string>()
+
+    const signals = computeSentimentDriftSignals(people, evidenceByPerson, dismissed, today)
+
+    expect(signals.find(s => s.type === 'sentiment_drift')).toBeUndefined()
+  })
+
+  it('produces no signal when prior window is empty', () => {
+    // Evidence only in recent window (no prior context for comparison)
+    const entries = Array.from({ length: 5 }, (_, i) => ({
+      occurred_at: daysAgo(i + 1),
+      sentiment: 'negative',
+    }))
+
+    const evidenceByPerson = new Map([['person-1', entries]])
+    const dismissed = new Set<string>()
+
+    const signals = computeSentimentDriftSignals(people, evidenceByPerson, dismissed, today)
+
+    expect(signals.find(s => s.type === 'sentiment_drift')).toBeUndefined()
+  })
+
+  it('skips dismissed persons', () => {
+    const entries = [
+      ...Array.from({ length: 8 }, (_, i) => ({ occurred_at: daysAgo(i + 1), sentiment: 'negative' })),
+      ...Array.from({ length: 2 }, (_, i) => ({ occurred_at: daysAgo(i + 20), sentiment: 'positive' })),
+      ...Array.from({ length: 2 }, (_, i) => ({ occurred_at: daysAgo(i + 31), sentiment: 'negative' })),
+      ...Array.from({ length: 8 }, (_, i) => ({ occurred_at: daysAgo(i + 40), sentiment: 'positive' })),
+    ]
+
+    const evidenceByPerson = new Map([['person-1', entries]])
+    // Dismiss the signal for person-1
+    const dismissed = new Set<string>(['sentiment_drift::person-1'])
+
+    const signals = computeSentimentDriftSignals(people, evidenceByPerson, dismissed, today)
+
+    expect(signals.find(s => s.type === 'sentiment_drift' && s.personId === 'person-1')).toBeUndefined()
+  })
+
+  it('can produce signals for multiple people independently', () => {
+    const makeEntries = (recentNeg: number, priorNeg: number) => [
+      ...Array.from({ length: recentNeg }, (_, i) => ({ occurred_at: daysAgo(i + 1), sentiment: 'negative' })),
+      ...Array.from({ length: 10 - recentNeg }, (_, i) => ({ occurred_at: daysAgo(i + 20), sentiment: 'positive' })),
+      ...Array.from({ length: priorNeg }, (_, i) => ({ occurred_at: daysAgo(i + 31), sentiment: 'negative' })),
+      ...Array.from({ length: 10 - priorNeg }, (_, i) => ({ occurred_at: daysAgo(i + 45), sentiment: 'positive' })),
+    ]
+
+    const evidenceByPerson = new Map([
+      ['person-1', makeEntries(8, 2)], // drift for person-1
+      ['person-2', makeEntries(2, 1)], // no drift for person-2
+    ])
+    const dismissed = new Set<string>()
+
+    const signals = computeSentimentDriftSignals(people, evidenceByPerson, dismissed, today)
+
+    expect(signals.find(s => s.personId === 'person-1')?.type).toBe('sentiment_drift')
+    expect(signals.find(s => s.personId === 'person-2')).toBeUndefined()
+  })
+
+  it('includes correct meta with rates and counts', () => {
+    const entries = [
+      ...Array.from({ length: 8 }, (_, i) => ({ occurred_at: daysAgo(i + 1), sentiment: 'negative' })),
+      ...Array.from({ length: 2 }, (_, i) => ({ occurred_at: daysAgo(i + 20), sentiment: 'positive' })),
+      ...Array.from({ length: 2 }, (_, i) => ({ occurred_at: daysAgo(i + 31), sentiment: 'negative' })),
+      ...Array.from({ length: 8 }, (_, i) => ({ occurred_at: daysAgo(i + 40), sentiment: 'positive' })),
+    ]
+
+    const evidenceByPerson = new Map([['person-1', entries]])
+    const dismissed = new Set<string>()
+
+    const signals = computeSentimentDriftSignals(people, evidenceByPerson, dismissed, today)
+    const signal = signals.find(s => s.personId === 'person-1')!
+
+    expect(signal.meta).toBeDefined()
+    expect((signal.meta as any).recentNegRate).toBeGreaterThan(0.6)
+    expect((signal.meta as any).priorNegRate).toBeLessThan(0.4)
+    expect(typeof (signal.meta as any).recentTotal).toBe('number')
+    expect(typeof (signal.meta as any).priorTotal).toBe('number')
+  })
+
+  it('ignores evidence entries outside the 60-day window', () => {
+    const entries = [
+      // These are fine (within 60 days)
+      ...Array.from({ length: 8 }, (_, i) => ({ occurred_at: daysAgo(i + 1), sentiment: 'negative' })),
+      ...Array.from({ length: 2 }, (_, i) => ({ occurred_at: daysAgo(i + 20), sentiment: 'positive' })),
+      ...Array.from({ length: 2 }, (_, i) => ({ occurred_at: daysAgo(i + 31), sentiment: 'negative' })),
+      ...Array.from({ length: 8 }, (_, i) => ({ occurred_at: daysAgo(i + 40), sentiment: 'positive' })),
+      // Too old — should be ignored
+      { occurred_at: daysAgo(65), sentiment: 'negative' },
+      { occurred_at: daysAgo(100), sentiment: 'negative' },
+    ]
+
+    const evidenceByPerson = new Map([['person-1', entries]])
+    const dismissed = new Set<string>()
+
+    const signals = computeSentimentDriftSignals(people, evidenceByPerson, dismissed, today)
+
+    // Should still fire (old entries don't inflate prior negatives enough to block)
+    const signal = signals.find(s => s.personId === 'person-1')
+    expect(signal).toBeDefined()
+  })
+})

--- a/lib/signals/__tests__/signals.test.ts
+++ b/lib/signals/__tests__/signals.test.ts
@@ -115,6 +115,7 @@ describe('SIGNAL_WEIGHTS completeness', () => {
     'overdue_task', 'no_recent_1on1', 'unresolved_action', 'no_evidence',
     'upcoming_deadline', 'missing_notes', 'overdue_follow_up',
     'ageing_follow_up', 'surfaced_follow_up', 'action_overload',
+    'sentiment_drift',
   ]
 
   it('has a weight entry for every signal type', () => {

--- a/lib/signals/compute.ts
+++ b/lib/signals/compute.ts
@@ -88,7 +88,7 @@ export async function loadSignalData() {
 
     supabase
       .from('evidence_entries')
-      .select('person_id, occurred_at')
+      .select('person_id, occurred_at, sentiment')
       .gte('occurred_at', nDaysAgoStr(90)),
 
     supabase
@@ -401,6 +401,107 @@ export async function computeActionItemSignals(
         meta: { taskId: task.id, taskTitle: task.title, meetingTitle: meeting.title, daysAgo },
       })
     }
+  }
+
+  return signals
+}
+
+/**
+ * Compute sentiment drift signals for all active people.
+ *
+ * Drift is detected when:
+ *   - recent 30 days: negative rate > 60%
+ *   - prior 30 days:  negative rate < 40%
+ *
+ * Severity escalates to critical if both the recent AND the prior period
+ * show the negative rate exceeding the threshold (i.e., persists across
+ * two consecutive periods).
+ *
+ * Requires evidence entries for each person passed in. Call
+ * `getEvidenceSentimentTimeline` per person externally, or pass raw entries.
+ */
+export interface SentimentPeriodStats {
+  positive: number
+  neutral: number
+  negative: number
+  total: number
+}
+
+export function computeSentimentDriftForPeriods(
+  recent: SentimentPeriodStats,
+  prior: SentimentPeriodStats
+): { drifting: boolean; severe: boolean; recentNegRate: number; priorNegRate: number } {
+  const recentNegRate = recent.total > 0 ? recent.negative / recent.total : 0
+  const priorNegRate  = prior.total  > 0 ? prior.negative  / prior.total  : 0
+
+  const drifting = recentNegRate > 0.6 && priorNegRate < 0.4
+  // Severe: trend persists — both periods show elevated negativity (prior > 40% too)
+  const severe = recentNegRate > 0.6 && priorNegRate >= 0.4
+
+  return { drifting: drifting || severe, severe, recentNegRate, priorNegRate }
+}
+
+/**
+ * Compute sentiment drift signals from raw evidence entries grouped by person.
+ * `evidenceByPerson` maps personId → array of {occurred_at, sentiment} rows.
+ */
+export function computeSentimentDriftSignals(
+  activePeople: Array<{ id: string; full_name: string }>,
+  evidenceByPerson: Map<string, Array<{ occurred_at: string; sentiment: string | null }>>,
+  dismissedSet: Set<string>,
+  today: Date
+): Signal[] {
+  const signals: Signal[] = []
+
+  const todayMs = today.getTime()
+  const DAY = 24 * 60 * 60 * 1000
+  const thirtyDaysMs = 30 * DAY
+  const sixtyDaysMs  = 60 * DAY
+
+  for (const person of activePeople) {
+    if (isDismissed(dismissedSet, 'sentiment_drift', person.id)) continue
+
+    const entries = evidenceByPerson.get(person.id) ?? []
+    if (entries.length === 0) continue
+
+    const recent: SentimentPeriodStats = { positive: 0, neutral: 0, negative: 0, total: 0 }
+    const prior:  SentimentPeriodStats = { positive: 0, neutral: 0, negative: 0, total: 0 }
+
+    for (const e of entries) {
+      const ageMs = todayMs - new Date(e.occurred_at + 'T00:00:00').getTime()
+      if (ageMs < 0 || ageMs > sixtyDaysMs) continue
+
+      const bucket = ageMs <= thirtyDaysMs ? recent : prior
+      bucket.total++
+      if (e.sentiment === 'positive') bucket.positive++
+      else if (e.sentiment === 'negative') bucket.negative++
+      else bucket.neutral++
+    }
+
+    // Need evidence in both windows to detect drift
+    if (recent.total === 0 || prior.total === 0) continue
+
+    const { drifting, severe, recentNegRate, priorNegRate } = computeSentimentDriftForPeriods(recent, prior)
+    if (!drifting) continue
+
+    const pct = Math.round(recentNegRate * 100)
+    signals.push({
+      type: 'sentiment_drift',
+      severity: severe ? 'critical' : 'warning',
+      message: `${person.full_name}'s evidence has been ${pct}% negative in the last 30 days`,
+      personId: person.id,
+      personName: person.full_name,
+      entityId: person.id,
+      entityType: 'person',
+      meta: {
+        recentNegRate,
+        priorNegRate,
+        recentTotal: recent.total,
+        priorTotal: prior.total,
+        recentNegative: recent.negative,
+        priorNegative: prior.negative,
+      },
+    })
   }
 
   return signals

--- a/lib/signals/types.ts
+++ b/lib/signals/types.ts
@@ -11,6 +11,7 @@ export type SignalType =
   | 'ageing_follow_up'
   | 'surfaced_follow_up'
   | 'action_overload'
+  | 'sentiment_drift'
 
 export interface Signal {
   type: SignalType
@@ -35,6 +36,7 @@ export const SIGNAL_WEIGHTS: Record<SignalType, number> = {
   ageing_follow_up: 3,
   surfaced_follow_up: 5,
   action_overload: 3,
+  sentiment_drift: 4,       // trending negative — notable attention
 }
 
 /** Critical signals get a bonus weight */


### PR DESCRIPTION
## Summary

Implements sentiment trend tracking for performance evidence, giving managers visibility into whether a direct report's trajectory is improving or declining over time.

## Changes

### Data Layer
- **`getEvidenceSentimentTimeline(personId, days)`** in evidence service — returns weekly aggregations of positive/neutral/negative evidence counts over a configurable window (default 60 days). Uses UTC-based date math to avoid timezone shift artefacts.

### Signal Logic
- New **`sentiment_drift`** signal type (weight 4) added to `SignalType` and `SIGNAL_WEIGHTS`
- **`computeSentimentDriftForPeriods`** — pure function comparing two 30-day windows:
  - **Warning**: recent >60% negative AND prior <40% negative
  - **Critical**: both periods elevated (prior ≥40%), indicating the trend persists across consecutive periods
- **`computeSentimentDriftSignals`** — iterates active people, buckets evidence into windows, emits signals with rate/count metadata
- Wired into weekly review via `computeAllSignals` — drift signals now surface in the weekly review panel

### UI
- **`SentimentTrendChart`** component on person detail page (above evidence section):
  - Stacked bar chart — positive (green) / neutral (grey) / negative (red) per week
  - Hover tooltip with weekly breakdown counts
  - Trend indicator: Improving / Stable / Trending negative (based on first vs second half negative rate delta)
  - Empty state for zero tagged evidence
  - Horizontally scrollable for dense data sets

## Tests
- 8 tests: `getEvidenceSentimentTimeline` (bucketing, edge cases, timezone safety, error handling)
- 16 tests: `computeSentimentDriftForPeriods` + `computeSentimentDriftSignals` (thresholds, severity escalation, dismissal, multi-person, meta fields)
- Updated `SIGNAL_WEIGHTS` completeness test to include `sentiment_drift`

All 394 passing (2 pre-existing date-sensitive task-card failures unrelated to this change).

Closes #102

---