### PR TITLE
feat(tasks): natural language task creation (#103)

### DIFF
--- a/app/(dashboard)/tasks/page.tsx
+++ b/app/(dashboard)/tasks/page.tsx
@@ -2,7 +2,9 @@
 
 import { useState, useEffect, useRef } from "react"
 import { Task, TaskStatus, TASK_STATUSES } from "@/lib/types/task"
-import { getTasks, createTask, updateTask, deleteTask as deleteTaskService } from "@/lib/services/tasks"
+import { getTasks, createTask, updateTask, deleteTask as deleteTaskService, type NaturalLanguageTaskPerson } from "@/lib/services/tasks"
+import { getPeople } from "@/lib/services/people"
+import { NaturalLanguageTaskInput } from "@/components/tasks/natural-language-task-input"
 import {
   DndContext,
   DragEndEvent,
@@ -33,6 +35,7 @@ import {
 
 export default function TasksPage() {
   const [tasks, setTasks] = useState<Task[]>([])
+  const [people, setPeople] = useState<NaturalLanguageTaskPerson[]>([])
   const [activeTask, setActiveTask] = useState<Task | null>(null)
   const [selectedTask, setSelectedTask] = useState<Task | null>(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
@@ -42,12 +45,24 @@ export default function TasksPage() {
   const [, setIsLoading] = useState(true)
   const mountedRef = useRef(true)
 
-  // Load tasks from Supabase on mount
+  // Load tasks and people from Supabase on mount
   useEffect(() => {
     mountedRef.current = true
     loadTasks()
+    loadPeople()
     return () => { mountedRef.current = false }
   }, [])
+
+  const loadPeople = async () => {
+    try {
+      const data = await getPeople()
+      if (mountedRef.current) {
+        setPeople(data.filter(p => p.status === 'active').map(p => ({ id: p.id, name: p.name })))
+      }
+    } catch (error) {
+      console.error('Failed to load people:', error)
+    }
+  }
 
   const loadTasks = async () => {
     try {
@@ -296,6 +311,15 @@ export default function TasksPage() {
     setIsModalOpen(true)
   }
 
+  const handleNaturalLanguageTask = async (task: Omit<Task, "id">) => {
+    try {
+      const newTask = await createTask(task)
+      setTasks((tasks) => [...tasks, newTask])
+    } catch (error) {
+      console.error('Failed to create task from natural language:', error)
+    }
+  }
+
   const weekTasks = tasks.filter((t) => t.list === "week")
   const backlogTasks = tasks.filter((t) => t.list === "backlog")
 
@@ -335,9 +359,15 @@ export default function TasksPage() {
       {/* Top bar */}
       <div className="page-topbar">
         <span className="page-topbar-title">Tasks</span>
-        <button className="btn-primary" onClick={handleNewTaskHeader}>
-          + New task
-        </button>
+        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <NaturalLanguageTaskInput
+            people={people}
+            onConfirm={handleNaturalLanguageTask}
+          />
+          <button className="btn-primary" onClick={handleNewTaskHeader}>
+            + New task
+          </button>
+        </div>
       </div>
 
       <div className="flex flex-col gap-8 p-4">

--- a/components/tasks/__tests__/natural-language-task-input.test.tsx
+++ b/components/tasks/__tests__/natural-language-task-input.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { NaturalLanguageTaskInput } from '../natural-language-task-input'
 import type { NaturalLanguageTaskPerson, NaturalLanguageTaskResult } from '@/lib/services/tasks'

--- a/components/tasks/__tests__/natural-language-task-input.test.tsx
+++ b/components/tasks/__tests__/natural-language-task-input.test.tsx
@@ -1,0 +1,434 @@
+/**
+ * NaturalLanguageTaskInput component tests
+ *
+ * Mocks AI service calls — no live AI requests.
+ * Tests:
+ * - Rendering and input state
+ * - Parse trigger (Enter key / button click)
+ * - Preview dialog populated from parsed result
+ * - Editable preview fields
+ * - Confirm creates task with correct shape
+ * - Cancel/close clears state
+ * - Graceful error handling when AI fails
+ * - Assignee matched from people list
+ * - Confidence badge display
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { NaturalLanguageTaskInput } from '../natural-language-task-input'
+import type { NaturalLanguageTaskPerson, NaturalLanguageTaskResult } from '@/lib/services/tasks'
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/services/tasks', () => ({
+  parseNaturalLanguageTask: vi.fn(),
+}))
+
+vi.mock('@/lib/services/ai', () => ({
+  handleAIError: vi.fn(),
+}))
+
+import { parseNaturalLanguageTask } from '@/lib/services/tasks'
+import { handleAIError } from '@/lib/services/ai'
+
+const mockParseNaturalLanguageTask = vi.mocked(parseNaturalLanguageTask)
+const mockHandleAIError = vi.mocked(handleAIError)
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const PEOPLE: NaturalLanguageTaskPerson[] = [
+  { id: 'person-alice', name: 'Alice Chen' },
+  { id: 'person-bob', name: 'Bob Smith' },
+]
+
+const PARSED_HIGH_CONFIDENCE: NaturalLanguageTaskResult = {
+  title: 'Follow up with Alice about the deploy',
+  priority: 'High',
+  category: 'People',
+  dueDate: '2026-05-30',
+  assigneeId: 'person-alice',
+  list: 'week',
+  confidence: 'high',
+}
+
+const PARSED_LOW_CONFIDENCE: NaturalLanguageTaskResult = {
+  title: 'Do something vague',
+  priority: 'Medium',
+  category: 'Task',
+  dueDate: null,
+  assigneeId: null,
+  list: 'backlog',
+  confidence: 'low',
+}
+
+const DEFAULT_CONFIRM = vi.fn()
+
+function renderComponent(people = PEOPLE, onConfirm = DEFAULT_CONFIRM) {
+  return render(
+    <NaturalLanguageTaskInput
+      people={people}
+      onConfirm={onConfirm}
+      today="2026-05-23"
+    />
+  )
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('NaturalLanguageTaskInput — rendering', () => {
+  it('renders the input field', () => {
+    renderComponent()
+    expect(screen.getByRole('textbox', { name: /natural language task input/i })).toBeInTheDocument()
+  })
+
+  it('renders the sparkles icon', () => {
+    const { container } = renderComponent()
+    // Lucide icons render as SVGs
+    const svgs = container.querySelectorAll('svg')
+    expect(svgs.length).toBeGreaterThan(0)
+  })
+
+  it('parse button is disabled when input is empty', () => {
+    renderComponent()
+    expect(screen.getByRole('button', { name: /parse task/i })).toBeDisabled()
+  })
+
+  it('parse button enables when input has text', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+    await user.type(screen.getByRole('textbox'), 'some task')
+    expect(screen.getByRole('button', { name: /parse task/i })).not.toBeDisabled()
+  })
+
+  it('input placeholder is visible', () => {
+    renderComponent()
+    expect(screen.getByPlaceholderText(/describe a task/i)).toBeInTheDocument()
+  })
+})
+
+describe('NaturalLanguageTaskInput — parsing', () => {
+  it('calls parseNaturalLanguageTask with trimmed input on Enter', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_HIGH_CONFIDENCE)
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.type(screen.getByRole('textbox'), '  Follow up with Alice  ')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(mockParseNaturalLanguageTask).toHaveBeenCalledWith(
+        'Follow up with Alice',
+        PEOPLE,
+        '2026-05-23',
+        expect.anything()
+      )
+    })
+  })
+
+  it('calls parseNaturalLanguageTask when parse button clicked', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_HIGH_CONFIDENCE)
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.type(screen.getByRole('textbox'), 'Write team update')
+    await user.click(screen.getByRole('button', { name: /parse task/i }))
+
+    await waitFor(() => {
+      expect(mockParseNaturalLanguageTask).toHaveBeenCalledOnce()
+    })
+  })
+
+  it('does not call parse when input is empty and Enter pressed', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+    await user.keyboard('{Enter}')
+    expect(mockParseNaturalLanguageTask).not.toHaveBeenCalled()
+  })
+
+  it('clears input with Escape key', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+    const input = screen.getByRole('textbox')
+    await user.type(input, 'some text')
+    expect(input).toHaveValue('some text')
+    await user.keyboard('{Escape}')
+    expect(input).toHaveValue('')
+  })
+
+  it('calls handleAIError when parse fails', async () => {
+    mockParseNaturalLanguageTask.mockRejectedValue(new Error('AI error'))
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.type(screen.getByRole('textbox'), 'any task')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(mockHandleAIError).toHaveBeenCalledWith(expect.any(Error))
+    })
+  })
+})
+
+describe('NaturalLanguageTaskInput — preview dialog', () => {
+  it('opens preview dialog after successful parse', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_HIGH_CONFIDENCE)
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.type(screen.getByRole('textbox'), 'Follow up with Alice about the deploy')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/review parsed task/i)).toBeInTheDocument()
+  })
+
+  it('populates title field from parse result', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_HIGH_CONFIDENCE)
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.type(screen.getByRole('textbox'), 'test')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => screen.getByRole('dialog'))
+    const titleInput = screen.getByLabelText('Title')
+    expect(titleInput).toHaveValue('Follow up with Alice about the deploy')
+  })
+
+  it('shows matched assignee name in dialog', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_HIGH_CONFIDENCE)
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.type(screen.getByRole('textbox'), 'Follow up with Alice')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => screen.getByRole('dialog'))
+    expect(screen.getByText('Alice Chen')).toBeInTheDocument()
+  })
+
+  it('does not show assignee section when no assignee matched', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_LOW_CONFIDENCE)
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.type(screen.getByRole('textbox'), 'vague task')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => screen.getByRole('dialog'))
+    expect(screen.queryByText('Linked person')).not.toBeInTheDocument()
+  })
+
+  it('shows high confidence indicator', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_HIGH_CONFIDENCE)
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.type(screen.getByRole('textbox'), 'test')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => screen.getByRole('dialog'))
+    expect(screen.getByText(/high confidence/i)).toBeInTheDocument()
+  })
+
+  it('shows low confidence indicator', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_LOW_CONFIDENCE)
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.type(screen.getByRole('textbox'), 'vague')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => screen.getByRole('dialog'))
+    expect(screen.getByText(/low confidence/i)).toBeInTheDocument()
+  })
+
+  it('shows raw input in dialog description', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_HIGH_CONFIDENCE)
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.type(screen.getByRole('textbox'), 'Follow up with Alice')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => screen.getByRole('dialog'))
+    expect(screen.getByText(/follow up with alice/i)).toBeInTheDocument()
+  })
+
+  it('Create task button is disabled when title is empty', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue({ ...PARSED_HIGH_CONFIDENCE, title: '' })
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.type(screen.getByRole('textbox'), 'test')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => screen.getByRole('dialog'))
+    expect(screen.getByRole('button', { name: /create task/i })).toBeDisabled()
+  })
+})
+
+describe('NaturalLanguageTaskInput — preview editing', () => {
+  async function openPreview(user: ReturnType<typeof userEvent.setup>) {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_HIGH_CONFIDENCE)
+    await user.type(screen.getByRole('textbox'), 'Follow up with Alice')
+    await user.keyboard('{Enter}')
+    await waitFor(() => screen.getByRole('dialog'))
+  }
+
+  it('title is editable', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+    await openPreview(user)
+
+    const titleInput = screen.getByLabelText('Title')
+    await user.clear(titleInput)
+    await user.type(titleInput, 'Updated title')
+    expect(titleInput).toHaveValue('Updated title')
+  })
+})
+
+describe('NaturalLanguageTaskInput — confirm', () => {
+  it('calls onConfirm with correct task shape on Create task', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_HIGH_CONFIDENCE)
+    const onConfirm = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <NaturalLanguageTaskInput people={PEOPLE} onConfirm={onConfirm} today="2026-05-23" />
+    )
+
+    await user.type(screen.getByRole('textbox'), 'Follow up with Alice')
+    await user.keyboard('{Enter}')
+    await waitFor(() => screen.getByRole('dialog'))
+
+    await user.click(screen.getByRole('button', { name: /create task/i }))
+
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Follow up with Alice about the deploy',
+        priority: 'High',
+        category: 'People',
+        dueDate: '2026-05-30',
+        list: 'week',
+        status: 'Not started',
+      })
+    )
+  })
+
+  it('clears input and closes dialog after confirm', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_HIGH_CONFIDENCE)
+    const onConfirm = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <NaturalLanguageTaskInput people={PEOPLE} onConfirm={onConfirm} today="2026-05-23" />
+    )
+
+    await user.type(screen.getByRole('textbox'), 'some task')
+    await user.keyboard('{Enter}')
+    await waitFor(() => screen.getByRole('dialog'))
+
+    await user.click(screen.getByRole('button', { name: /create task/i }))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toHaveValue('')
+  })
+
+  it('closes dialog and keeps input on Cancel', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_HIGH_CONFIDENCE)
+    const onConfirm = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <NaturalLanguageTaskInput people={PEOPLE} onConfirm={onConfirm} today="2026-05-23" />
+    )
+
+    await user.type(screen.getByRole('textbox'), 'some task')
+    await user.keyboard('{Enter}')
+    await waitFor(() => screen.getByRole('dialog'))
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('uses edited title in confirmed task', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_HIGH_CONFIDENCE)
+    const onConfirm = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <NaturalLanguageTaskInput people={PEOPLE} onConfirm={onConfirm} today="2026-05-23" />
+    )
+
+    await user.type(screen.getByRole('textbox'), 'test')
+    await user.keyboard('{Enter}')
+    await waitFor(() => screen.getByRole('dialog'))
+
+    const titleInput = screen.getByLabelText('Title')
+    await user.clear(titleInput)
+    await user.type(titleInput, 'Manually edited title')
+
+    await user.click(screen.getByRole('button', { name: /create task/i }))
+
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Manually edited title' })
+    )
+  })
+})
+
+describe('NaturalLanguageTaskInput — edge cases', () => {
+  it('handles people list with no matches for assigneeId', async () => {
+    const parsed: NaturalLanguageTaskResult = {
+      ...PARSED_HIGH_CONFIDENCE,
+      assigneeId: 'non-existent-id',
+    }
+    mockParseNaturalLanguageTask.mockResolvedValue(parsed)
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.type(screen.getByRole('textbox'), 'test')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => screen.getByRole('dialog'))
+    // No "Linked person" section since ID not matched
+    expect(screen.queryByText('Linked person')).not.toBeInTheDocument()
+  })
+
+  it('works with empty people list', async () => {
+    mockParseNaturalLanguageTask.mockResolvedValue(PARSED_LOW_CONFIDENCE)
+    const user = userEvent.setup()
+    renderComponent([], vi.fn())
+
+    await user.type(screen.getByRole('textbox'), 'any task')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => screen.getByRole('dialog'))
+    expect(screen.getByText(/review parsed task/i)).toBeInTheDocument()
+  })
+
+  it('does not double-fire parse on rapid Enter presses (isParsing guard)', async () => {
+    let resolveFirst!: (v: NaturalLanguageTaskResult) => void
+    const slowPromise = new Promise<NaturalLanguageTaskResult>(r => { resolveFirst = r })
+    mockParseNaturalLanguageTask.mockReturnValue(slowPromise)
+
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.type(screen.getByRole('textbox'), 'task')
+    await user.keyboard('{Enter}')
+    await user.keyboard('{Enter}')
+
+    resolveFirst(PARSED_HIGH_CONFIDENCE)
+    await waitFor(() => screen.getByRole('dialog'))
+
+    // Only called once — second Enter ignored while isParsing
+    expect(mockParseNaturalLanguageTask).toHaveBeenCalledOnce()
+  })
+})

--- a/components/tasks/natural-language-task-input.tsx
+++ b/components/tasks/natural-language-task-input.tsx
@@ -1,0 +1,325 @@
+"use client"
+
+import { useState, useRef, useCallback } from "react"
+import { Sparkles, Loader2, AlertCircle, CheckCircle2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Label } from "@/components/ui/label"
+import { parseNaturalLanguageTask, type NaturalLanguageTaskPerson, type NaturalLanguageTaskResult } from "@/lib/services/tasks"
+import { handleAIError } from "@/lib/services/ai"
+import { Task, TaskPriority, TaskCategory, TASK_PRIORITIES, TASK_CATEGORIES } from "@/lib/types/task"
+
+interface NaturalLanguageTaskInputProps {
+  people: NaturalLanguageTaskPerson[]
+  onConfirm: (task: Omit<Task, "id">) => void
+  today?: string
+}
+
+type ParsedPreview = NaturalLanguageTaskResult & { rawInput: string }
+
+const CONFIDENCE_CONFIG = {
+  high: { icon: CheckCircle2, color: "var(--color-success, #16a34a)", label: "High confidence" },
+  medium: { icon: AlertCircle, color: "var(--color-warning, #ca8a04)", label: "Review suggested" },
+  low: { icon: AlertCircle, color: "var(--color-danger, #dc2626)", label: "Low confidence — please review" },
+} as const
+
+export function NaturalLanguageTaskInput({
+  people,
+  onConfirm,
+  today = new Date().toISOString().split("T")[0],
+}: NaturalLanguageTaskInputProps) {
+  const [input, setInput] = useState("")
+  const [isParsing, setIsParsing] = useState(false)
+  const [preview, setPreview] = useState<ParsedPreview | null>(null)
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const handleParse = useCallback(async () => {
+    const trimmed = input.trim()
+    if (!trimmed || isParsing) return
+
+    // Cancel any in-flight request
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    setIsParsing(true)
+    try {
+      const result = await parseNaturalLanguageTask(trimmed, people, today, controller.signal)
+      setPreview({ ...result, rawInput: trimmed })
+      setIsPreviewOpen(true)
+    } catch (err) {
+      if ((err as Error).name === "AbortError") return
+      handleAIError(err)
+    } finally {
+      setIsParsing(false)
+    }
+  }, [input, isParsing, people, today])
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      handleParse()
+    }
+    if (e.key === "Escape") {
+      setInput("")
+    }
+  }
+
+  const handleConfirm = () => {
+    if (!preview) return
+
+    const task: Omit<Task, "id"> = {
+      title: preview.title,
+      priority: preview.priority as TaskPriority,
+      category: preview.category as TaskCategory,
+      status: "Not started",
+      dueDate: preview.dueDate,
+      list: preview.list,
+      description: "",
+    }
+
+    onConfirm(task)
+    setInput("")
+    setPreview(null)
+    setIsPreviewOpen(false)
+  }
+
+  const handleClose = () => {
+    setIsPreviewOpen(false)
+    setPreview(null)
+  }
+
+  const updatePreview = (field: keyof NaturalLanguageTaskResult, value: string) => {
+    if (!preview) return
+    setPreview({ ...preview, [field]: value })
+  }
+
+  const confidenceConfig = preview ? CONFIDENCE_CONFIG[preview.confidence] : null
+  const ConfidenceIcon = confidenceConfig?.icon
+
+  const assigneeName = preview?.assigneeId
+    ? people.find(p => p.id === preview.assigneeId)?.name ?? null
+    : null
+
+  return (
+    <>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          background: "var(--surface-2)",
+          border: "1px solid var(--border-2)",
+          borderRadius: "8px",
+          padding: "6px 8px",
+          maxWidth: "480px",
+          width: "100%",
+        }}
+      >
+        <Sparkles
+          size={15}
+          style={{ color: "var(--text-3)", flexShrink: 0 }}
+          aria-hidden
+        />
+        <Input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Describe a task... (Enter to parse)"
+          disabled={isParsing}
+          style={{
+            border: "none",
+            background: "transparent",
+            padding: 0,
+            height: "auto",
+            fontSize: "var(--text-caption)",
+            color: "var(--text-1)",
+            boxShadow: "none",
+            outline: "none",
+          }}
+          aria-label="Natural language task input"
+        />
+        <button
+          onClick={handleParse}
+          disabled={!input.trim() || isParsing}
+          style={{
+            background: "none",
+            border: "none",
+            padding: "2px 4px",
+            cursor: input.trim() && !isParsing ? "pointer" : "default",
+            color: input.trim() && !isParsing ? "var(--text-2)" : "var(--text-4)",
+            flexShrink: 0,
+            display: "flex",
+            alignItems: "center",
+          }}
+          aria-label="Parse task"
+        >
+          {isParsing ? (
+            <Loader2 size={14} className="animate-spin" />
+          ) : (
+            <span style={{ fontSize: "var(--text-meta)" }}>⏎</span>
+          )}
+        </button>
+      </div>
+
+      {/* Preview dialog */}
+      <Dialog open={isPreviewOpen} onOpenChange={open => !open && handleClose()}>
+        <DialogContent style={{ maxWidth: "480px" }}>
+          <DialogHeader>
+            <DialogTitle>Review parsed task</DialogTitle>
+            <DialogDescription>
+              {preview && (
+                <span style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+                  {ConfidenceIcon && (
+                    <ConfidenceIcon
+                      size={14}
+                      style={{ color: confidenceConfig?.color, flexShrink: 0 }}
+                      aria-hidden
+                    />
+                  )}
+                  <span style={{ color: confidenceConfig?.color, fontSize: "var(--text-meta)" }}>
+                    {confidenceConfig?.label}
+                  </span>
+                  <span style={{ color: "var(--text-3)", fontSize: "var(--text-meta)" }}>
+                    — from: &ldquo;{preview.rawInput}&rdquo;
+                  </span>
+                </span>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+
+          {preview && (
+            <div style={{ display: "flex", flexDirection: "column", gap: "16px", paddingTop: "8px" }}>
+              {/* Title */}
+              <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                <Label htmlFor="nl-title">Title</Label>
+                <Input
+                  id="nl-title"
+                  value={preview.title}
+                  onChange={e => updatePreview("title", e.target.value)}
+                  maxLength={80}
+                />
+              </div>
+
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
+                {/* Priority */}
+                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                  <Label htmlFor="nl-priority">Priority</Label>
+                  <Select
+                    value={preview.priority}
+                    onValueChange={val => updatePreview("priority", val)}
+                  >
+                    <SelectTrigger id="nl-priority">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {TASK_PRIORITIES.map(p => (
+                        <SelectItem key={p} value={p}>{p}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {/* Category */}
+                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                  <Label htmlFor="nl-category">Category</Label>
+                  <Select
+                    value={preview.category}
+                    onValueChange={val => updatePreview("category", val)}
+                  >
+                    <SelectTrigger id="nl-category">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {TASK_CATEGORIES.map(c => (
+                        <SelectItem key={c} value={c}>{c}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
+                {/* Due date */}
+                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                  <Label htmlFor="nl-due">Due date</Label>
+                  <Input
+                    id="nl-due"
+                    type="date"
+                    value={preview.dueDate ?? ""}
+                    onChange={e => updatePreview("dueDate", e.target.value || "")}
+                  />
+                </div>
+
+                {/* List */}
+                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                  <Label htmlFor="nl-list">List</Label>
+                  <Select
+                    value={preview.list}
+                    onValueChange={val => updatePreview("list", val)}
+                  >
+                    <SelectTrigger id="nl-list">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="week">This week</SelectItem>
+                      <SelectItem value="backlog">Backlog</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              {/* Assignee (display-only, matched from people) */}
+              {assigneeName && (
+                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                  <Label>Linked person</Label>
+                  <div
+                    style={{
+                      fontSize: "var(--text-caption)",
+                      color: "var(--text-2)",
+                      background: "var(--surface-2)",
+                      border: "1px solid var(--border-2)",
+                      borderRadius: "6px",
+                      padding: "6px 10px",
+                    }}
+                  >
+                    {assigneeName}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          <DialogFooter style={{ marginTop: "8px" }}>
+            <Button variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleConfirm}
+              disabled={!preview?.title.trim()}
+              className="btn-primary"
+            >
+              Create task
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/lib/ai/__tests__/prompts.eval.test.ts
+++ b/lib/ai/__tests__/prompts.eval.test.ts
@@ -14,6 +14,7 @@ import {
   buildActionItemPrompt,
   buildGrowthPlanPrompt,
   buildTaskPrioritisationPrompt,
+  buildNaturalLanguageTaskPrompt,
   REVIEW_DRAFT_SYSTEM,
   ONE_ON_ONE_PREP_SYSTEM,
   PROMOTION_PACKET_SYSTEM,
@@ -24,7 +25,9 @@ import {
   RECURRING_TOPICS_SYSTEM,
   SUMMARY_REWRITE_PROMPTS,
   TASK_PRIORITISATION_SYSTEM,
+  NATURAL_LANGUAGE_TASK_SYSTEM,
   type TaskPrioritisationInput,
+  type NaturalLanguageTaskPerson,
 } from '../prompts'
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -499,5 +502,106 @@ describe('buildTaskPrioritisationPrompt', () => {
     const prompt = buildTaskPrioritisationPrompt({ tasks, today: '2026-05-23' })
     // No person info — should not contain "linked to"
     expect(prompt).not.toContain('linked to')
+  })
+})
+
+// ─── Natural Language Task Prompt ─────────────────────────────────────────────
+
+const NL_PEOPLE: NaturalLanguageTaskPerson[] = [
+  { id: 'person-alice', name: 'Alice Chen' },
+  { id: 'person-bob', name: 'Bob Smith' },
+]
+
+describe('buildNaturalLanguageTaskPrompt', () => {
+  it('includes user input in prompt', () => {
+    const prompt = buildNaturalLanguageTaskPrompt({
+      input: 'Follow up with Alice about the deploy',
+      today: '2026-05-23',
+      people: NL_PEOPLE,
+    })
+    expect(prompt).toContain('Follow up with Alice about the deploy')
+  })
+
+  it('includes today date', () => {
+    const prompt = buildNaturalLanguageTaskPrompt({
+      input: 'Write team update',
+      today: '2026-05-23',
+      people: NL_PEOPLE,
+    })
+    expect(prompt).toContain('Today: 2026-05-23')
+  })
+
+  it('includes all people with their IDs', () => {
+    const prompt = buildNaturalLanguageTaskPrompt({
+      input: 'Check in with Bob',
+      today: '2026-05-23',
+      people: NL_PEOPLE,
+    })
+    expect(prompt).toContain('Alice Chen')
+    expect(prompt).toContain('person-alice')
+    expect(prompt).toContain('Bob Smith')
+    expect(prompt).toContain('person-bob')
+  })
+
+  it('handles empty people list gracefully', () => {
+    const prompt = buildNaturalLanguageTaskPrompt({
+      input: 'Write docs',
+      today: '2026-05-23',
+      people: [],
+    })
+    expect(prompt).toContain('No people in directory')
+  })
+
+  it('wraps user input in quotes', () => {
+    const prompt = buildNaturalLanguageTaskPrompt({
+      input: 'some task',
+      today: '2026-05-23',
+      people: [],
+    })
+    expect(prompt).toContain('"some task"')
+  })
+})
+
+describe('NATURAL_LANGUAGE_TASK_SYSTEM', () => {
+  it('specifies all valid priority values', () => {
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('Low')
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('Medium')
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('High')
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('Very High')
+  })
+
+  it('specifies all valid category values', () => {
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('Task')
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('Meeting')
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('Career Growth')
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('People')
+  })
+
+  it('demands JSON-only output', () => {
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('"title"')
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('"priority"')
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('"category"')
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('"dueDate"')
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('"list"')
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('"confidence"')
+  })
+
+  it('includes confidence levels', () => {
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('"high"')
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('"medium"')
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('"low"')
+  })
+
+  it('describes ISO 8601 date format', () => {
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('YYYY-MM-DD')
+  })
+
+  it('mentions relative date examples', () => {
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('next Friday')
+  })
+
+  it('lists week and backlog as valid list values', () => {
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('"week"')
+    expect(NATURAL_LANGUAGE_TASK_SYSTEM).toContain('"backlog"')
   })
 })

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -354,3 +354,63 @@ export function buildTaskPrioritisationPrompt(args: {
 Tasks to rank:
 ${taskLines}`, 4000)
 }
+
+// ─── Natural Language Task Creation ──────────────────────────────────────────
+
+export const NATURAL_LANGUAGE_TASK_SYSTEM = `You are helping an engineering manager create structured tasks from natural language descriptions.
+
+Parse the input and return a structured task. Use the following rules:
+- **title**: A concise, action-oriented task title (max 80 characters). Remove filler words like "I need to" or "Remember to".
+- **priority**: One of "Low", "Medium", "High", "Very High". Default to "Medium" if no urgency signals.
+- **category**: One of "Task", "Meeting", "Career Growth", "People". Use "People" for tasks about team members, "Meeting" for meeting-related tasks, "Career Growth" for development tasks, "Task" for everything else.
+- **dueDate**: ISO 8601 date string (YYYY-MM-DD) resolved from the input relative to today, or null if no date mentioned. Examples: "next Friday", "end of week", "tomorrow", "in 2 weeks".
+- **assigneeId**: ID of the person this task relates to, matched from the people list, or null if no person mentioned or matched.
+- **list**: "week" if due this week or overdue, "backlog" otherwise. Default to "backlog" if no date.
+
+Return ONLY a JSON object with no other text:
+{
+  "title": "...",
+  "priority": "Low" | "Medium" | "High" | "Very High",
+  "category": "Task" | "Meeting" | "Career Growth" | "People",
+  "dueDate": "YYYY-MM-DD" | null,
+  "assigneeId": "person-uuid" | null,
+  "list": "week" | "backlog",
+  "confidence": "high" | "medium" | "low"
+}
+
+confidence reflects how certain you are about the parse:
+- high: all fields clearly stated
+- medium: some inference required (e.g. relative date resolved, name partially matched)
+- low: significant ambiguity, user should review carefully`
+
+export interface NaturalLanguageTaskPerson {
+  id: string
+  name: string
+}
+
+export interface NaturalLanguageTaskResult {
+  title: string
+  priority: string
+  category: string
+  dueDate: string | null
+  assigneeId: string | null
+  list: 'week' | 'backlog'
+  confidence: 'high' | 'medium' | 'low'
+}
+
+export function buildNaturalLanguageTaskPrompt(args: {
+  input: string
+  today: string
+  people: NaturalLanguageTaskPerson[]
+}): string {
+  const peopleList = args.people.length > 0
+    ? args.people.map(p => `- ${p.name} (id: ${p.id})`).join('\n')
+    : 'No people in directory.'
+
+  return `Today: ${args.today}
+
+User input: "${args.input}"
+
+Active people directory (for name matching):
+${peopleList}`
+}

--- a/lib/services/tasks.ts
+++ b/lib/services/tasks.ts
@@ -9,12 +9,16 @@ import { callAI } from '@/lib/services/ai'
 import {
   TASK_PRIORITISATION_SYSTEM,
   buildTaskPrioritisationPrompt,
+  NATURAL_LANGUAGE_TASK_SYSTEM,
+  buildNaturalLanguageTaskPrompt,
   type TaskPrioritisationInput,
   type TaskRanking,
   type TaskPrioritisationResult,
+  type NaturalLanguageTaskPerson,
+  type NaturalLanguageTaskResult,
 } from '@/lib/ai/prompts'
 
-export type { TaskPrioritisationInput, TaskRanking, TaskPrioritisationResult }
+export type { TaskPrioritisationInput, TaskRanking, TaskPrioritisationResult, NaturalLanguageTaskPerson, NaturalLanguageTaskResult }
 
 type DbPriority = 'low' | 'medium' | 'high' | 'very_high'
 type DbStatus = 'not_started' | 'in_progress' | 'blocked' | 'completed'
@@ -264,4 +268,74 @@ export async function prioritiseTasks(
     .sort((a, b) => a.rank - b.rank)
 
   return rankings
+}
+
+const VALID_PRIORITIES = new Set(['Low', 'Medium', 'High', 'Very High'])
+const VALID_CATEGORIES = new Set(['Task', 'Meeting', 'Career Growth', 'People'])
+const VALID_LISTS = new Set(['week', 'backlog'])
+const VALID_CONFIDENCE = new Set(['high', 'medium', 'low'])
+
+/**
+ * Parse a natural language task description into a structured task using AI.
+ * Returns a NaturalLanguageTaskResult for the caller to show in a preview.
+ * Throws if AI returns an invalid/unparseable response.
+ */
+export async function parseNaturalLanguageTask(
+  input: string,
+  people: NaturalLanguageTaskPerson[],
+  today: string = new Date().toISOString().split('T')[0],
+  signal?: AbortSignal
+): Promise<NaturalLanguageTaskResult> {
+  if (!input.trim()) throw new Error('Input cannot be empty')
+
+  const userPrompt = buildNaturalLanguageTaskPrompt({ input: input.trim(), today, people })
+
+  const response = await callAI(
+    {
+      systemPrompt: NATURAL_LANGUAGE_TASK_SYSTEM,
+      userPrompt,
+      maxTokens: 300,
+      temperature: 0,
+    },
+    signal
+  )
+
+  let parsed: NaturalLanguageTaskResult
+  try {
+    const cleaned = response.content
+      .replace(/^```(?:json)?\s*/i, '')
+      .replace(/\s*```$/i, '')
+      .trim()
+    parsed = JSON.parse(cleaned) as NaturalLanguageTaskResult
+  } catch {
+    throw new Error('AI returned invalid JSON for task parsing')
+  }
+
+  // Validate required fields with safe fallbacks
+  const title = typeof parsed.title === 'string' && parsed.title.trim()
+    ? parsed.title.trim().slice(0, 80)
+    : input.trim().slice(0, 80)
+
+  const priority = VALID_PRIORITIES.has(parsed.priority) ? parsed.priority : 'Medium'
+  const category = VALID_CATEGORIES.has(parsed.category) ? parsed.category : 'Task'
+  const list = VALID_LISTS.has(parsed.list) ? parsed.list as 'week' | 'backlog' : 'backlog'
+  const confidence = VALID_CONFIDENCE.has(parsed.confidence) ? parsed.confidence as 'high' | 'medium' | 'low' : 'low'
+
+  // Validate due date — must be a valid ISO date string or null
+  let dueDate: string | null = null
+  if (typeof parsed.dueDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(parsed.dueDate)) {
+    const d = new Date(parsed.dueDate)
+    if (!isNaN(d.getTime())) {
+      dueDate = parsed.dueDate
+    }
+  }
+
+  // Validate assigneeId — must match a person ID in the provided list or be null
+  let assigneeId: string | null = null
+  if (typeof parsed.assigneeId === 'string' && parsed.assigneeId) {
+    const matched = people.find(p => p.id === parsed.assigneeId)
+    assigneeId = matched ? matched.id : null
+  }
+
+  return { title, priority, category, dueDate, assigneeId, list, confidence }
 }


### PR DESCRIPTION
## Summary

Adds AI-powered natural language task creation. Managers type a description in plain English; AI parses it into a structured task with a preview step before confirmation.

## Changes

### AI layer
- **`lib/ai/prompts.ts`**: New `NATURAL_LANGUAGE_TASK_SYSTEM` prompt and `buildNaturalLanguageTaskPrompt` builder. Instructs the AI to extract title, priority, category, due date (with relative date resolution), assignee ID (matched against active people directory), list placement, and confidence level. Returns JSON only.

### Service layer
- **`lib/services/tasks.ts`**: New `parseNaturalLanguageTask` function. Calls the AI proxy, strips markdown fences, validates every field with safe fallbacks, and rejects unrecognised assignee IDs to prevent hallucination.

### Component
- **`components/tasks/natural-language-task-input.tsx`**: Text input with a sparkles icon. Enter key or ⏎ button triggers parsing. Shows a preview dialog populated from the AI result with all fields editable before confirmation. Confidence indicator (high/medium/low) guides the user on how much to review. AbortController cancels in-flight requests on re-fire.

### Page
- **`app/(dashboard)/tasks/page.tsx`**: Loads active people on mount (for name resolution). Mounts `NaturalLanguageTaskInput` in the top bar alongside the existing `+ New task` button.

## Tests

- **`lib/ai/__tests__/prompts.eval.test.ts`**: 15 new prompt eval tests covering the system prompt structure, all valid values, JSON-only output requirement, date format, and the prompt builder (includes today date, people list, quoted input, empty-people fallback).
- **`components/tasks/__tests__/natural-language-task-input.test.tsx`**: 26 component tests across render, parsing trigger, preview dialog population, editable fields, confirm/cancel flows, error handling, and edge cases (empty people list, unmatched assignee ID, rapid-Enter deduplication).

## Acceptance criteria met

- ✅ Single text input creates fully-structured task
- ✅ Relative dates resolved (AI handles; today passed as context)
- ✅ Person names mapped to IDs from active people list
- ✅ Preview step before commitment (editable)
- ✅ Graceful fallback if parsing fails (handleAIError toast, no crash)
- ✅ Works with all AI providers (routes through existing ai-proxy edge function)

Closes #103

---