### PR TITLE
feat: cross-team competency gap summary (#104)

### DIFF
--- a/app/(dashboard)/team-health/page.tsx
+++ b/app/(dashboard)/team-health/page.tsx
@@ -1,0 +1,467 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Activity } from 'lucide-react'
+import { getPeople } from '@/lib/services/people'
+import { getTeams, type Team } from '@/lib/services/teams'
+import {
+  getTeamCompetencySnapshot,
+  type TeamCompetencySnapshot,
+} from '@/lib/services/competency'
+import { callAI, handleAIError } from '@/lib/services/ai'
+import {
+  TEAM_COMPETENCY_SUMMARY_SYSTEM,
+  buildTeamCompetencySummaryPromptFromSnapshot,
+} from '@/lib/ai/prompts'
+import { AIButton, AIGeneratedBadge } from '@/components/ui/ai-button'
+import { useAIConfig } from '@/lib/hooks/use-ai-config'
+
+// ─── Bar chart component ──────────────────────────────────────────────────────
+
+interface GapBarProps {
+  areaName: string
+  pctBelowExpected: number
+  pctAtExpected: number
+  pctAboveExpected: number
+  totalAssessed: number
+  belowExpected: number
+}
+
+function GapBar({ areaName, pctBelowExpected, pctAtExpected, pctAboveExpected, totalAssessed, belowExpected }: GapBarProps) {
+  const pctBelow = Math.round(pctBelowExpected)
+  const pctAt = Math.round(pctAtExpected)
+  const pctAbove = Math.round(pctAboveExpected)
+
+  const severity = pctBelow >= 60 ? 'high' : pctBelow >= 35 ? 'medium' : 'low'
+  const barColors = {
+    below: severity === 'high' ? '#f87171' : severity === 'medium' ? '#fbbf24' : '#6b7280',
+    at: '#4ade80',
+    above: '#34d399',
+  }
+
+  return (
+    <div style={{ marginBottom: '10px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '4px' }}>
+        <span style={{
+          fontSize: 'var(--text-label)',
+          color: 'var(--text-2)',
+          width: '200px',
+          flexShrink: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}>
+          {areaName}
+        </span>
+
+        {/* Stacked bar */}
+        <div style={{
+          flex: 1,
+          height: '14px',
+          borderRadius: '3px',
+          overflow: 'hidden',
+          background: 'var(--surf-3)',
+          display: 'flex',
+        }}>
+          {pctBelow > 0 && (
+            <div style={{ width: `${pctBelow}%`, background: barColors.below, transition: 'width 0.3s' }} title={`${pctBelow}% below expected`} />
+          )}
+          {pctAt > 0 && (
+            <div style={{ width: `${pctAt}%`, background: barColors.at, transition: 'width 0.3s' }} title={`${pctAt}% at expected`} />
+          )}
+          {pctAbove > 0 && (
+            <div style={{ width: `${pctAbove}%`, background: barColors.above, transition: 'width 0.3s' }} title={`${pctAbove}% above expected`} />
+          )}
+        </div>
+
+        {/* Labels */}
+        <div style={{ display: 'flex', gap: '8px', width: '200px', flexShrink: 0, justifyContent: 'flex-end' }}>
+          {pctBelow > 0 && (
+            <span style={{ fontSize: 'var(--text-caption)', color: barColors.below, fontVariantNumeric: 'tabular-nums' }}>
+              {pctBelow}% below ({belowExpected}/{totalAssessed})
+            </span>
+          )}
+          {pctBelow === 0 && (
+            <span style={{ fontSize: 'var(--text-caption)', color: 'var(--text-3)', fontVariantNumeric: 'tabular-nums' }}>
+              ✓ {totalAssessed} assessed
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Legend ───────────────────────────────────────────────────────────────────
+
+function ChartLegend() {
+  return (
+    <div style={{ display: 'flex', gap: '16px', marginBottom: '16px', flexWrap: 'wrap' }}>
+      {[
+        { color: '#f87171', label: 'Below expected (≥60%)' },
+        { color: '#fbbf24', label: 'Below expected (35–59%)' },
+        { color: '#6b7280', label: 'Below expected (<35%)' },
+        { color: '#4ade80', label: 'At expected' },
+        { color: '#34d399', label: 'Above expected' },
+      ].map(({ color, label }) => (
+        <div key={label} style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
+          <span style={{ width: '10px', height: '10px', borderRadius: '2px', background: color, display: 'inline-block', flexShrink: 0 }} />
+          <span style={{ fontSize: 'var(--text-caption)', color: 'var(--text-3)' }}>{label}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ─── AI narrative ─────────────────────────────────────────────────────────────
+
+function AINarrative({ bullets }: { bullets: string[] }) {
+  return (
+    <ul style={{ margin: 0, padding: '0 0 0 18px' }}>
+      {bullets.map((b, i) => (
+        <li key={i} style={{ fontSize: 'var(--text-label)', color: 'var(--text-2)', marginBottom: '6px', lineHeight: 1.5 }}>
+          {b}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+function EmptyState({ assessedPeople, totalPeople }: { assessedPeople: number; totalPeople: number }) {
+  return (
+    <div style={{ textAlign: 'center', padding: '48px 24px', color: 'var(--text-3)' }}>
+      <Activity style={{ width: '32px', height: '32px', margin: '0 auto 12px', opacity: 0.4 }} />
+      {totalPeople === 0 ? (
+        <p>No active team members found. Add people first.</p>
+      ) : assessedPeople === 0 ? (
+        <p>No competency assessments yet. Assess team members from their profile pages.</p>
+      ) : (
+        <p>No competency data for this team.</p>
+      )}
+    </div>
+  )
+}
+
+// ─── Team filter ──────────────────────────────────────────────────────────────
+
+interface TeamFilterProps {
+  teams: Team[]
+  selectedTeamId: string | null
+  onChange: (id: string | null) => void
+}
+
+function TeamFilter({ teams, selectedTeamId, onChange }: TeamFilterProps) {
+  return (
+    <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+      <button
+        onClick={() => onChange(null)}
+        style={{
+          background: selectedTeamId === null ? 'var(--surf-3)' : 'var(--surf-2)',
+          border: `1px solid ${selectedTeamId === null ? 'var(--border-3)' : 'var(--border-1)'}`,
+          borderRadius: '4px',
+          color: selectedTeamId === null ? 'var(--text-1)' : 'var(--text-3)',
+          fontSize: 'var(--text-meta)',
+          padding: '4px 10px',
+          cursor: 'pointer',
+          fontFamily: 'var(--font-sans)',
+        }}
+      >
+        All teams
+      </button>
+      {teams.map(t => (
+        <button
+          key={t.id}
+          onClick={() => onChange(t.id)}
+          style={{
+            background: selectedTeamId === t.id ? 'var(--surf-3)' : 'var(--surf-2)',
+            border: `1px solid ${selectedTeamId === t.id ? 'var(--border-3)' : 'var(--border-1)'}`,
+            borderRadius: '4px',
+            color: selectedTeamId === t.id ? 'var(--text-1)' : 'var(--text-3)',
+            fontSize: 'var(--text-meta)',
+            padding: '4px 10px',
+            cursor: 'pointer',
+            fontFamily: 'var(--font-sans)',
+          }}
+        >
+          {t.name}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// ─── Stats strip ─────────────────────────────────────────────────────────────
+
+function StatsStrip({ snapshot }: { snapshot: TeamCompetencySnapshot }) {
+  const topGap = snapshot.areas[0]
+  const avgPctBelow = snapshot.areas.length > 0
+    ? snapshot.areas.reduce((s, a) => s + a.pctBelowExpected, 0) / snapshot.areas.length
+    : 0
+
+  return (
+    <div style={{ display: 'flex', gap: '12px', marginBottom: '20px', flexWrap: 'wrap' }}>
+      <div style={{ background: 'var(--surf)', border: '1px solid var(--border-1)', borderRadius: '6px', padding: '10px 16px', minWidth: '120px' }}>
+        <div style={{ fontSize: 'var(--text-overline)', color: 'var(--text-3)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: '2px' }}>Assessed</div>
+        <div style={{ fontSize: 'var(--text-section)', fontWeight: 700, color: 'var(--text-1)' }}>
+          {snapshot.assessedPeople}/{snapshot.totalPeople}
+        </div>
+      </div>
+      <div style={{ background: 'var(--surf)', border: '1px solid var(--border-1)', borderRadius: '6px', padding: '10px 16px', minWidth: '120px' }}>
+        <div style={{ fontSize: 'var(--text-overline)', color: 'var(--text-3)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: '2px' }}>Areas tracked</div>
+        <div style={{ fontSize: 'var(--text-section)', fontWeight: 700, color: 'var(--text-1)' }}>{snapshot.areas.length}</div>
+      </div>
+      <div style={{ background: 'var(--surf)', border: '1px solid var(--border-1)', borderRadius: '6px', padding: '10px 16px', minWidth: '160px' }}>
+        <div style={{ fontSize: 'var(--text-overline)', color: 'var(--text-3)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: '2px' }}>Avg % below expected</div>
+        <div style={{ fontSize: 'var(--text-section)', fontWeight: 700, color: avgPctBelow >= 50 ? '#f87171' : avgPctBelow >= 30 ? '#fbbf24' : '#4ade80' }}>
+          {Math.round(avgPctBelow)}%
+        </div>
+      </div>
+      {topGap && (
+        <div style={{ background: 'var(--surf)', border: '1px solid var(--border-1)', borderRadius: '6px', padding: '10px 16px', flex: 1, minWidth: '200px' }}>
+          <div style={{ fontSize: 'var(--text-overline)', color: 'var(--text-3)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: '2px' }}>Top gap area</div>
+          <div style={{ fontSize: 'var(--text-body)', fontWeight: 600, color: '#f87171' }}>
+            {topGap.areaName} <span style={{ fontWeight: 400, color: 'var(--text-3)', fontSize: 'var(--text-meta)' }}>({Math.round(topGap.pctBelowExpected)}% below)</span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function TeamHealthPage() {
+  const [teams, setTeams] = useState<Team[]>([])
+  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null)
+  const [snapshot, setSnapshot] = useState<TeamCompetencySnapshot | null>(null)
+  const [loadingData, setLoadingData] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [narrative, setNarrative] = useState<string[]>([])
+  const [generating, setGenerating] = useState(false)
+  const [narrativeShown, setNarrativeShown] = useState(false)
+
+  const aiConfig = useAIConfig()
+
+  // Load teams once
+  useEffect(() => {
+    getTeams().then(ts => setTeams(ts.filter(t => t.status === 'active'))).catch(() => {})
+  }, [])
+
+  // Reload snapshot when filter changes
+  const loadSnapshot = useCallback(async (teamId: string | null) => {
+    setLoadingData(true)
+    setError(null)
+    setNarrative([])
+    setNarrativeShown(false)
+    try {
+      const people = await getPeople()
+      const activePeople = people.filter(p => p.status === 'active')
+
+      let filteredPeople = activePeople
+      if (teamId !== null) {
+        const team = teams.find(tm => tm.id === teamId)
+        filteredPeople = team
+          ? activePeople.filter(p => p.teams.includes(team.name))
+          : activePeople
+      }
+
+      const snap = await getTeamCompetencySnapshot(
+        filteredPeople.map(p => p.id),
+        teamId
+      )
+      setSnapshot(snap)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load data')
+    } finally {
+      setLoadingData(false)
+    }
+  }, [teams])
+
+  // Trigger load when teamId or teams list changes
+  useEffect(() => {
+    if (teams.length >= 0) {  // always run, even with 0 teams
+      loadSnapshot(selectedTeamId)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedTeamId, teams])
+
+  const handleTeamChange = (id: string | null) => {
+    setSelectedTeamId(id)
+  }
+
+  const handleGenerateSummary = async () => {
+    if (!snapshot) return
+    setGenerating(true)
+    try {
+      const selectedTeam = teams.find(t => t.id === selectedTeamId)
+      const teamName = selectedTeam?.name ?? 'All Teams'
+
+      const userPrompt = buildTeamCompetencySummaryPromptFromSnapshot({
+        teamName,
+        snapshot,
+      })
+
+      const result = await callAI({
+        systemPrompt: TEAM_COMPETENCY_SUMMARY_SYSTEM,
+        userPrompt,
+        maxTokens: 500,
+        temperature: 0.3,
+      })
+
+      // Parse bullets from markdown list
+      const bullets = result.content
+        .split('\n')
+        .map(l => l.replace(/^[\s-*•]+/, '').trim())
+        .filter(l => l.length > 0)
+
+      setNarrative(bullets)
+      setNarrativeShown(true)
+    } catch (err) {
+      handleAIError(err)
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  const selectedTeamName = teams.find(t => t.id === selectedTeamId)?.name ?? 'All Teams'
+
+  return (
+    <>
+      <div className="page-topbar">
+        <span className="page-topbar-title">Team Competency Health</span>
+      </div>
+
+      <div className="page-content">
+        {/* Subtitle */}
+        <div style={{ marginBottom: '20px' }}>
+          <p style={{ color: 'var(--text-3)', fontSize: 'var(--text-label)' }}>
+            Aggregate view of which competency areas have the most room for growth across your team.
+          </p>
+        </div>
+
+        {/* Team filter */}
+        {teams.length > 0 && (
+          <div style={{ marginBottom: '20px' }}>
+            <TeamFilter
+              teams={teams}
+              selectedTeamId={selectedTeamId}
+              onChange={handleTeamChange}
+            />
+          </div>
+        )}
+
+        {/* Error */}
+        {error && (
+          <div style={{ background: '#2a0a0a', border: '1px solid #5a2020', borderRadius: '6px', padding: '12px 16px', marginBottom: '16px', color: '#f87171', fontSize: 'var(--text-label)' }}>
+            {error}
+          </div>
+        )}
+
+        {/* Loading */}
+        {loadingData && (
+          <div style={{ padding: '32px', color: 'var(--text-3)', fontSize: 'var(--text-meta)' }}>
+            Loading competency data…
+          </div>
+        )}
+
+        {/* Content */}
+        {!loadingData && snapshot && (
+          <>
+            {/* Stats strip */}
+            {snapshot.assessedPeople > 0 && (
+              <StatsStrip snapshot={snapshot} />
+            )}
+
+            {/* Empty state */}
+            {snapshot.areas.length === 0 && (
+              <EmptyState assessedPeople={snapshot.assessedPeople} totalPeople={snapshot.totalPeople} />
+            )}
+
+            {/* Chart section */}
+            {snapshot.areas.length > 0 && (
+              <div style={{ background: 'var(--surf)', border: '1px solid var(--border-1)', borderRadius: '8px', padding: '20px', marginBottom: '20px' }}>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '16px' }}>
+                  <div>
+                    <h2 style={{ margin: 0 }}>Areas ranked by gap severity</h2>
+                    <p style={{ fontSize: 'var(--text-caption)', color: 'var(--text-3)', marginTop: '2px' }}>
+                      {selectedTeamName} · {snapshot.assessedPeople} of {snapshot.totalPeople} people assessed
+                    </p>
+                  </div>
+                </div>
+
+                <ChartLegend />
+
+                <div>
+                  {snapshot.areas.map(area => {
+                    const total = area.totalAssessed
+                    const pctAt = total > 0 ? (area.atExpected / total) * 100 : 0
+                    const pctAbove = total > 0 ? (area.aboveExpected / total) * 100 : 0
+                    return (
+                      <GapBar
+                        key={area.areaName}
+                        areaName={area.areaName}
+                        pctBelowExpected={area.pctBelowExpected}
+                        pctAtExpected={pctAt}
+                        pctAboveExpected={pctAbove}
+                        totalAssessed={area.totalAssessed}
+                        belowExpected={area.belowExpected}
+                      />
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* AI narrative section */}
+            {snapshot.areas.length > 0 && (
+              <div style={{ background: 'var(--surf)', border: '1px solid var(--border-1)', borderRadius: '8px', padding: '20px' }}>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: narrativeShown ? '14px' : '0' }}>
+                  <div>
+                    <h2 style={{ margin: 0 }}>AI Summary</h2>
+                    <p style={{ fontSize: 'var(--text-caption)', color: 'var(--text-3)', marginTop: '2px' }}>
+                      Strategic narrative — skip-level ready
+                    </p>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                    {narrativeShown && (
+                      <AIGeneratedBadge onDismiss={() => { setNarrative([]); setNarrativeShown(false) }} />
+                    )}
+                    <AIButton
+                      configured={aiConfig.configured}
+                      loading={aiConfig.loading}
+                      generating={generating}
+                      onClick={handleGenerateSummary}
+                      label={narrativeShown ? 'Regenerate' : 'Generate summary'}
+                      tooltip={aiConfig.tooltip}
+                      showSetupLink={true}
+                    />
+                  </div>
+                </div>
+
+                {narrativeShown && narrative.length > 0 && (
+                  <AINarrative bullets={narrative} />
+                )}
+
+                {narrativeShown && narrative.length === 0 && (
+                  <p style={{ fontSize: 'var(--text-label)', color: 'var(--text-3)', marginTop: '8px' }}>
+                    No summary generated. Try again.
+                  </p>
+                )}
+
+                {!narrativeShown && !generating && (
+                  <p style={{ fontSize: 'var(--text-caption)', color: 'var(--text-3)', marginTop: '8px' }}>
+                    Generate an AI narrative identifying top gaps, patterns, and suggested focus areas.
+                    No individual names are included.
+                  </p>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -21,6 +21,7 @@ import {
   Award,
   Settings,
   LogOut,
+  BarChart2,
 } from "lucide-react"
 import { createClient } from "@/lib/supabase/client"
 import { fetchSignalCounts } from "@/lib/hooks/use-weekly-review-signals"
@@ -42,6 +43,7 @@ const navigation: NavItem[] = [
   { name: "Evidence", href: "/evidence", icon: BookOpen },
   { name: "Follow-ups", href: "/follow-ups", icon: ListChecks },
   { name: "Career Framework", href: "/framework", icon: Award },
+  { name: "Team Health", href: "/team-health", icon: BarChart2 },
   { label: "Output" },
   { name: "Weekly Summary", href: "/summary", icon: FileText },
 ]

--- a/lib/ai/__tests__/team-competency-prompt.test.ts
+++ b/lib/ai/__tests__/team-competency-prompt.test.ts
@@ -1,0 +1,172 @@
+/**
+ * buildTeamCompetencySummaryPrompt — unit tests
+ * Pure functions; no mocks needed.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  buildTeamCompetencySummaryPrompt,
+  buildTeamCompetencySummaryPromptFromSnapshot,
+  TEAM_COMPETENCY_SUMMARY_SYSTEM,
+  type TeamCompetencySummaryArea,
+} from '../prompts'
+
+const makeArea = (overrides: Partial<TeamCompetencySummaryArea> = {}): TeamCompetencySummaryArea => ({
+  areaName: 'System Design',
+  totalAssessed: 4,
+  belowExpected: 2,
+  atExpected: 1,
+  aboveExpected: 1,
+  avgGap: -0.5,
+  pctBelowExpected: 50,
+  ...overrides,
+})
+
+describe('TEAM_COMPETENCY_SUMMARY_SYSTEM', () => {
+  it('exists and is a non-empty string', () => {
+    expect(typeof TEAM_COMPETENCY_SUMMARY_SYSTEM).toBe('string')
+    expect(TEAM_COMPETENCY_SUMMARY_SYSTEM.length).toBeGreaterThan(50)
+  })
+
+  it('instructs the model not to name individuals', () => {
+    expect(TEAM_COMPETENCY_SUMMARY_SYSTEM.toLowerCase()).toContain('aggregate')
+    expect(TEAM_COMPETENCY_SUMMARY_SYSTEM.toLowerCase()).toMatch(/never name individuals|aggregate only/)
+  })
+
+  it('mentions skip-level audience', () => {
+    expect(TEAM_COMPETENCY_SUMMARY_SYSTEM.toLowerCase()).toContain('skip-level')
+  })
+})
+
+describe('buildTeamCompetencySummaryPrompt', () => {
+  it('includes team name in output', () => {
+    const prompt = buildTeamCompetencySummaryPrompt({
+      teamName: 'Platform Engineering',
+      totalPeople: 5,
+      assessedPeople: 4,
+      areas: [makeArea()],
+    })
+    expect(prompt).toContain('Platform Engineering')
+  })
+
+  it('includes people counts', () => {
+    const prompt = buildTeamCompetencySummaryPrompt({
+      teamName: 'My Team',
+      totalPeople: 6,
+      assessedPeople: 3,
+      areas: [makeArea()],
+    })
+    expect(prompt).toContain('6')
+    expect(prompt).toContain('3')
+  })
+
+  it('includes area name in output', () => {
+    const prompt = buildTeamCompetencySummaryPrompt({
+      teamName: 'My Team',
+      totalPeople: 3,
+      assessedPeople: 3,
+      areas: [makeArea({ areaName: 'Communication' })],
+    })
+    expect(prompt).toContain('Communication')
+  })
+
+  it('shows pct below expected rounded to integer', () => {
+    const prompt = buildTeamCompetencySummaryPrompt({
+      teamName: 'My Team',
+      totalPeople: 4,
+      assessedPeople: 4,
+      areas: [makeArea({ pctBelowExpected: 66.666 })],
+    })
+    expect(prompt).toContain('67%')
+  })
+
+  it('shows negative avg gap with sign', () => {
+    const prompt = buildTeamCompetencySummaryPrompt({
+      teamName: 'My Team',
+      totalPeople: 2,
+      assessedPeople: 2,
+      areas: [makeArea({ avgGap: -1.5 })],
+    })
+    expect(prompt).toContain('-1.5')
+  })
+
+  it('shows positive avg gap with + prefix', () => {
+    const prompt = buildTeamCompetencySummaryPrompt({
+      teamName: 'My Team',
+      totalPeople: 2,
+      assessedPeople: 2,
+      areas: [makeArea({ avgGap: 1.0 })],
+    })
+    // avgGap.toFixed(1) = "1.0", and since "1.0" > "0" the + prefix is shown
+    expect(prompt).toContain('+1.0')
+  })
+
+  it('handles empty areas with a no-data message', () => {
+    const prompt = buildTeamCompetencySummaryPrompt({
+      teamName: 'Empty Team',
+      totalPeople: 5,
+      assessedPeople: 0,
+      areas: [],
+    })
+    expect(prompt).toContain('Empty Team')
+    expect(prompt.toLowerCase()).toContain('no competency assessments')
+  })
+
+  it('limits output to at most 15 areas', () => {
+    const manyAreas = Array.from({ length: 20 }, (_, i) =>
+      makeArea({ areaName: `Area ${i + 1}` })
+    )
+    const prompt = buildTeamCompetencySummaryPrompt({
+      teamName: 'Big Team',
+      totalPeople: 20,
+      assessedPeople: 20,
+      areas: manyAreas,
+    })
+    // Areas 16-20 should not appear
+    expect(prompt).not.toContain('Area 16')
+    expect(prompt).not.toContain('Area 20')
+    // Area 15 should appear
+    expect(prompt).toContain('Area 15')
+  })
+
+  it('lists multiple areas each on their own line', () => {
+    const areas = [
+      makeArea({ areaName: 'System Design', pctBelowExpected: 75 }),
+      makeArea({ areaName: 'Communication', pctBelowExpected: 40 }),
+    ]
+    const prompt = buildTeamCompetencySummaryPrompt({
+      teamName: 'My Team',
+      totalPeople: 4,
+      assessedPeople: 4,
+      areas,
+    })
+    expect(prompt).toContain('System Design')
+    expect(prompt).toContain('Communication')
+  })
+})
+
+describe('buildTeamCompetencySummaryPromptFromSnapshot', () => {
+  it('delegates correctly to buildTeamCompetencySummaryPrompt', () => {
+    const snapshot = {
+      totalPeople: 5,
+      assessedPeople: 3,
+      areas: [makeArea({ areaName: 'Delivery' })],
+    }
+    const prompt = buildTeamCompetencySummaryPromptFromSnapshot({
+      teamName: 'Core Team',
+      snapshot,
+    })
+    expect(prompt).toContain('Core Team')
+    expect(prompt).toContain('Delivery')
+    expect(prompt).toContain('5')
+    expect(prompt).toContain('3')
+  })
+
+  it('passes empty areas through to produce no-data message', () => {
+    const prompt = buildTeamCompetencySummaryPromptFromSnapshot({
+      teamName: 'Ghost Team',
+      snapshot: { totalPeople: 2, assessedPeople: 0, areas: [] },
+    })
+    expect(prompt.toLowerCase()).toContain('no competency assessments')
+  })
+})

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -414,3 +414,67 @@ User input: "${args.input}"
 Active people directory (for name matching):
 ${peopleList}`
 }
+
+// ─── Team Competency Summary ──────────────────────────────────────────────────
+
+export const TEAM_COMPETENCY_SUMMARY_SYSTEM = `You are a strategic advisor helping an engineering manager understand their team's competency health. You write concise, skip-level-ready summaries based on aggregate data.
+
+Generate a 3-5 bullet narrative identifying:
+- The top 2-3 systemic skill gaps (areas with the highest % below expected)
+- Notable patterns across areas (e.g. execution vs. communication imbalance)
+- Suggested focus areas for training investment or hiring
+
+Rules:
+- Never name individuals — aggregate only
+- Use clear, direct language suitable for sharing with senior leadership
+- Ground every point in the data provided
+- If data is limited (< 3 people assessed), note this caveat
+- Return plain markdown bullets — no headers, no JSON`
+
+export interface TeamCompetencySummaryArea {
+  areaName: string
+  totalAssessed: number
+  belowExpected: number
+  atExpected: number
+  aboveExpected: number
+  avgGap: number
+  pctBelowExpected: number
+}
+
+export function buildTeamCompetencySummaryPrompt(args: {
+  teamName: string
+  totalPeople: number
+  assessedPeople: number
+  areas: TeamCompetencySummaryArea[]
+}): string {
+  if (args.areas.length === 0) {
+    return `Team: ${args.teamName}\nTotal people: ${args.totalPeople}\nNo competency assessments recorded yet.`
+  }
+
+  const areaLines = args.areas
+    .slice(0, 15)
+    .map(a => {
+      const pct = Math.round(a.pctBelowExpected)
+      const avg = a.avgGap.toFixed(1)
+      return `- ${a.areaName}: ${pct}% below expected (${a.belowExpected}/${a.totalAssessed} people), avg gap ${avg > '0' ? '+' : ''}${avg} levels`
+    })
+    .join('\n')
+
+  return truncateToTokenBudget(`Team: ${args.teamName}
+People: ${args.totalPeople} total, ${args.assessedPeople} assessed
+
+Competency areas ranked by % below expected level:
+${areaLines}`, 3000)
+}
+
+export function buildTeamCompetencySummaryPromptFromSnapshot(args: {
+  teamName: string
+  snapshot: { totalPeople: number; assessedPeople: number; areas: TeamCompetencySummaryArea[] }
+}): string {
+  return buildTeamCompetencySummaryPrompt({
+    teamName: args.teamName,
+    totalPeople: args.snapshot.totalPeople,
+    assessedPeople: args.snapshot.assessedPeople,
+    areas: args.snapshot.areas,
+  })
+}

--- a/lib/services/__tests__/competency.snapshot.test.ts
+++ b/lib/services/__tests__/competency.snapshot.test.ts
@@ -1,0 +1,293 @@
+/**
+ * getTeamCompetencySnapshot — unit tests
+ * Tests the pure aggregation logic via mocked Supabase.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { getTeamCompetencySnapshot } from '../competency'
+import { mockSupabaseClient } from '../../../test/mocks/supabase'
+
+describe('getTeamCompetencySnapshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty snapshot when personIds is empty', async () => {
+    const result = await getTeamCompetencySnapshot([])
+    expect(result.areas).toEqual([])
+    expect(result.totalPeople).toBe(0)
+    expect(result.assessedPeople).toBe(0)
+    expect(result.teamId).toBeNull()
+  })
+
+  it('returns empty areas when no assessments exist for people', async () => {
+    mockSupabaseClient.from = vi.fn().mockImplementation((table: string) => {
+      if (table === 'competency_assessments') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          }),
+        }
+      }
+      if (table === 'people') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockResolvedValue({
+              data: [{ id: 'p1', level: 'Mid' }],
+              error: null,
+            }),
+          }),
+        }
+      }
+      return { select: vi.fn().mockResolvedValue({ data: [], error: null }) }
+    })
+
+    const result = await getTeamCompetencySnapshot(['p1'])
+    expect(result.areas).toHaveLength(0)
+    expect(result.totalPeople).toBe(1)
+    expect(result.assessedPeople).toBe(0)
+  })
+
+  it('computes belowExpected / atExpected / aboveExpected correctly', async () => {
+    // Person p1 is Mid (expected score=2), assessed at Junior (score=1) → gap=-1 → below
+    // Person p2 is Mid (expected score=2), assessed at Mid (score=2) → gap=0 → at
+    // Person p3 is Mid (expected score=2), assessed at Senior (score=3) → gap=+1 → above
+    const assessments = [
+      { person_id: 'p1', area_id: 'a1', assessed_level: 'Junior', score: 1, competency_areas: { name: 'System Design' } },
+      { person_id: 'p2', area_id: 'a1', assessed_level: 'Mid',    score: 2, competency_areas: { name: 'System Design' } },
+      { person_id: 'p3', area_id: 'a1', assessed_level: 'Senior', score: 3, competency_areas: { name: 'System Design' } },
+    ]
+    const people = [
+      { id: 'p1', level: 'Mid' },
+      { id: 'p2', level: 'Mid' },
+      { id: 'p3', level: 'Mid' },
+    ]
+
+    mockSupabaseClient.from = vi.fn().mockImplementation((table: string) => {
+      if (table === 'competency_assessments') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({ data: assessments, error: null }),
+            }),
+          }),
+        }
+      }
+      if (table === 'people') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockResolvedValue({ data: people, error: null }),
+          }),
+        }
+      }
+      return { select: vi.fn().mockResolvedValue({ data: [], error: null }) }
+    })
+
+    const result = await getTeamCompetencySnapshot(['p1', 'p2', 'p3'])
+    expect(result.areas).toHaveLength(1)
+    const area = result.areas[0]
+    expect(area.areaName).toBe('System Design')
+    expect(area.totalAssessed).toBe(3)
+    expect(area.belowExpected).toBe(1)
+    expect(area.atExpected).toBe(1)
+    expect(area.aboveExpected).toBe(1)
+    expect(area.pctBelowExpected).toBeCloseTo(33.33, 1)
+    expect(area.avgGap).toBeCloseTo(0, 5)
+  })
+
+  it('deduplicates: keeps only latest assessment per person+area', async () => {
+    // p1 has two assessments for a1 — the first (Junior) is newer, second (Mid) is older
+    // order is descending by assessed_at, so first row wins
+    const assessments = [
+      { person_id: 'p1', area_id: 'a1', assessed_level: 'Junior', score: 1, competency_areas: { name: 'Delivery' } },
+      { person_id: 'p1', area_id: 'a1', assessed_level: 'Mid',    score: 2, competency_areas: { name: 'Delivery' } },
+    ]
+    const people = [{ id: 'p1', level: 'Senior' }]
+
+    mockSupabaseClient.from = vi.fn().mockImplementation((table: string) => {
+      if (table === 'competency_assessments') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({ data: assessments, error: null }),
+            }),
+          }),
+        }
+      }
+      if (table === 'people') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockResolvedValue({ data: people, error: null }),
+          }),
+        }
+      }
+      return { select: vi.fn().mockResolvedValue({ data: [], error: null }) }
+    })
+
+    const result = await getTeamCompetencySnapshot(['p1'])
+    expect(result.areas).toHaveLength(1)
+    // Only one row kept — totalAssessed should be 1
+    expect(result.areas[0].totalAssessed).toBe(1)
+    // Junior (1) vs Senior expected (3) → gap = -2 → below
+    expect(result.areas[0].belowExpected).toBe(1)
+    expect(result.areas[0].atExpected).toBe(0)
+  })
+
+  it('sorts areas by pctBelowExpected descending', async () => {
+    // area-A: 2/2 below = 100%
+    // area-B: 1/2 below = 50%
+    // area-C: 0/2 below = 0%
+    const assessments = [
+      { person_id: 'p1', area_id: 'a1', assessed_level: 'Junior', score: 1, competency_areas: { name: 'Area-A' } },
+      { person_id: 'p2', area_id: 'a1', assessed_level: 'Junior', score: 1, competency_areas: { name: 'Area-A' } },
+      { person_id: 'p1', area_id: 'a2', assessed_level: 'Junior', score: 1, competency_areas: { name: 'Area-B' } },
+      { person_id: 'p2', area_id: 'a2', assessed_level: 'Senior', score: 3, competency_areas: { name: 'Area-B' } },
+      { person_id: 'p1', area_id: 'a3', assessed_level: 'Senior', score: 3, competency_areas: { name: 'Area-C' } },
+      { person_id: 'p2', area_id: 'a3', assessed_level: 'Senior', score: 3, competency_areas: { name: 'Area-C' } },
+    ]
+    const people = [{ id: 'p1', level: 'Mid' }, { id: 'p2', level: 'Mid' }]
+
+    mockSupabaseClient.from = vi.fn().mockImplementation((table: string) => {
+      if (table === 'competency_assessments') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({ data: assessments, error: null }),
+            }),
+          }),
+        }
+      }
+      if (table === 'people') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockResolvedValue({ data: people, error: null }),
+          }),
+        }
+      }
+      return { select: vi.fn().mockResolvedValue({ data: [], error: null }) }
+    })
+
+    const result = await getTeamCompetencySnapshot(['p1', 'p2'])
+    expect(result.areas[0].areaName).toBe('Area-A')
+    expect(result.areas[1].areaName).toBe('Area-B')
+    expect(result.areas[2].areaName).toBe('Area-C')
+    expect(result.areas[0].pctBelowExpected).toBe(100)
+    expect(result.areas[2].pctBelowExpected).toBe(0)
+  })
+
+  it('counts assessed people correctly (distinct person_ids with assessments)', async () => {
+    const assessments = [
+      { person_id: 'p1', area_id: 'a1', assessed_level: 'Mid', score: 2, competency_areas: { name: 'Area-A' } },
+      { person_id: 'p1', area_id: 'a2', assessed_level: 'Mid', score: 2, competency_areas: { name: 'Area-B' } },
+      // p2 has no assessments
+    ]
+    const people = [{ id: 'p1', level: 'Mid' }, { id: 'p2', level: 'Mid' }]
+
+    mockSupabaseClient.from = vi.fn().mockImplementation((table: string) => {
+      if (table === 'competency_assessments') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({ data: assessments, error: null }),
+            }),
+          }),
+        }
+      }
+      if (table === 'people') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockResolvedValue({ data: people, error: null }),
+          }),
+        }
+      }
+      return { select: vi.fn().mockResolvedValue({ data: [], error: null }) }
+    })
+
+    const result = await getTeamCompetencySnapshot(['p1', 'p2'])
+    expect(result.totalPeople).toBe(2)
+    expect(result.assessedPeople).toBe(1)
+  })
+
+  it('propagates teamId to snapshot result', async () => {
+    mockSupabaseClient.from = vi.fn().mockImplementation((table: string) => {
+      if (table === 'competency_assessments') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          }),
+        }
+      }
+      if (table === 'people') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockResolvedValue({ data: [{ id: 'p1', level: 'Mid' }], error: null }),
+          }),
+        }
+      }
+      return { select: vi.fn().mockResolvedValue({ data: [], error: null }) }
+    })
+
+    const result = await getTeamCompetencySnapshot(['p1'], 'team-42')
+    expect(result.teamId).toBe('team-42')
+  })
+
+  it('falls back to Mid when person level is missing', async () => {
+    // Person has null level — expected score should be Mid(2)
+    const assessments = [
+      { person_id: 'p1', area_id: 'a1', assessed_level: 'Junior', score: 1, competency_areas: { name: 'Delivery' } },
+    ]
+    const people = [{ id: 'p1', level: null }]
+
+    mockSupabaseClient.from = vi.fn().mockImplementation((table: string) => {
+      if (table === 'competency_assessments') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({ data: assessments, error: null }),
+            }),
+          }),
+        }
+      }
+      if (table === 'people') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockResolvedValue({ data: people, error: null }),
+          }),
+        }
+      }
+      return { select: vi.fn().mockResolvedValue({ data: [], error: null }) }
+    })
+
+    const result = await getTeamCompetencySnapshot(['p1'])
+    expect(result.areas[0].belowExpected).toBe(1)   // Junior(1) < Mid(2)
+    expect(result.areas[0].avgGap).toBe(-1)
+  })
+
+  it('throws when assessment query returns an error', async () => {
+    mockSupabaseClient.from = vi.fn().mockImplementation((table: string) => {
+      if (table === 'competency_assessments') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+            }),
+          }),
+        }
+      }
+      if (table === 'people') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockResolvedValue({ data: [{ id: 'p1', level: 'Mid' }], error: null }),
+          }),
+        }
+      }
+      return { select: vi.fn().mockResolvedValue({ data: [], error: null }) }
+    })
+
+    await expect(getTeamCompetencySnapshot(['p1'])).rejects.toMatchObject({ message: 'DB error' })
+  })
+})

--- a/lib/services/competency.ts
+++ b/lib/services/competency.ts
@@ -337,6 +337,104 @@ export async function getAssessmentsForTeam(personIds: string[]): Promise<Compet
   return (data ?? []).map(r => rowToAssessment(r as AssessmentRow))
 }
 
+// ─── Team Competency Snapshot ─────────────────────────────────────────────────
+
+export interface CompetencyAreaSnapshot {
+  areaName: string
+  totalAssessed: number
+  belowExpected: number
+  atExpected: number
+  aboveExpected: number
+  avgGap: number          // negative = below, 0 = at, positive = above
+  pctBelowExpected: number
+}
+
+export interface TeamCompetencySnapshot {
+  areas: CompetencyAreaSnapshot[]
+  totalPeople: number
+  assessedPeople: number
+  teamId: string | null   // null = all teams
+}
+
+/**
+ * Aggregate competency assessments across active people, optionally filtered by team.
+ * Uses each person's expected level from their `level` field to compute gap.
+ * Returns areas ranked by % below expected (highest gap first).
+ */
+export async function getTeamCompetencySnapshot(
+  personIds: string[],
+  teamId: string | null = null
+): Promise<TeamCompetencySnapshot> {
+  if (personIds.length === 0) {
+    return { areas: [], totalPeople: 0, assessedPeople: 0, teamId }
+  }
+
+  const supabase = createClient()
+
+  // Fetch all assessments for these people, keeping only latest per person+area
+  const { data: rawAssessments, error: assessErr } = await supabase
+    .from('competency_assessments')
+    .select('person_id, area_id, assessed_level, score, competency_areas(name)')
+    .in('person_id', personIds)
+    .order('assessed_at', { ascending: false })
+  if (assessErr) throw assessErr
+
+  // Fetch people levels to compute expected score
+  const { data: rawPeople, error: peopleErr } = await supabase
+    .from('people')
+    .select('id, level')
+    .in('id', personIds)
+  if (peopleErr) throw peopleErr
+
+  const personLevelMap = new Map<string, string>(
+    (rawPeople ?? []).map((p: { id: string; level: string | null }) => [p.id, p.level ?? 'Mid'])
+  )
+
+  // Deduplicate: keep latest assessment per (person, area)
+  type RawRow = { person_id: string; area_id: string; assessed_level: string; score: number; competency_areas: { name: string } | null }
+  const seen = new Map<string, RawRow>()
+  for (const row of (rawAssessments ?? []) as unknown as RawRow[]) {
+    const key = `${row.person_id}|${row.area_id}`
+    if (!seen.has(key)) seen.set(key, row)
+  }
+
+  // Group by area
+  const byArea = new Map<string, { areaName: string; gaps: number[] }>()
+  for (const row of seen.values()) {
+    const areaName = row.competency_areas?.name ?? row.area_id
+    const expectedScore = levelToScore(personLevelMap.get(row.person_id) ?? 'Mid')
+    const gap = row.score - expectedScore
+
+    if (!byArea.has(row.area_id)) {
+      byArea.set(row.area_id, { areaName, gaps: [] })
+    }
+    byArea.get(row.area_id)!.gaps.push(gap)
+  }
+
+  const assessedPeopleSet = new Set<string>(
+    Array.from(seen.values()).map(r => r.person_id)
+  )
+
+  const areas: CompetencyAreaSnapshot[] = Array.from(byArea.entries())
+    .map(([, { areaName, gaps }]) => {
+      const totalAssessed = gaps.length
+      const belowExpected = gaps.filter(g => g < 0).length
+      const atExpected = gaps.filter(g => g === 0).length
+      const aboveExpected = gaps.filter(g => g > 0).length
+      const avgGap = totalAssessed > 0 ? gaps.reduce((a, b) => a + b, 0) / totalAssessed : 0
+      const pctBelowExpected = totalAssessed > 0 ? (belowExpected / totalAssessed) * 100 : 0
+      return { areaName, totalAssessed, belowExpected, atExpected, aboveExpected, avgGap, pctBelowExpected }
+    })
+    .sort((a, b) => b.pctBelowExpected - a.pctBelowExpected)
+
+  return {
+    areas,
+    totalPeople: personIds.length,
+    assessedPeople: assessedPeopleSet.size,
+    teamId,
+  }
+}
+
 export async function upsertAssessment(input: {
   personId: string
   areaId: string


### PR DESCRIPTION
## Summary

Closes #104.

Aggregate view of which competency areas have the most room for growth across the team. Surfaces systemic skill gaps without exposing individual-level data.

## Changes

### Service layer
- `getTeamCompetencySnapshot(personIds, teamId?)` in `lib/services/competency.ts`
  - Queries all competency assessments for a set of people
  - Deduplicates: keeps only latest assessment per person+area
  - Computes `belowExpected` / `atExpected` / `aboveExpected` counts, average gap, and % below expected per area
  - Returns areas ranked by % below expected (highest gap first)

### AI prompts
- `TEAM_COMPETENCY_SUMMARY_SYSTEM` + `buildTeamCompetencySummaryPrompt()` in `lib/ai/prompts.ts`
  - Skip-level-ready narrative (3-5 bullets)
  - No individual names — aggregate only
  - Flags low-data caveat when fewer than 3 people assessed

### UI — `/team-health`
- Stacked bar chart: areas ranked by % below expected, colour-coded by severity (red ≥60%, amber 35-59%, grey <35%)
- Team filter: scope chart to active members of a specific team
- Stats strip: assessed/total people, avg % below, top gap area
- AI summary: "Generate summary" button → `callAI()` → 3-5 bullet narrative
- Empty states for: no people, no assessments, no team data

### Navigation
- "Team Health" link added to sidebar (BarChart2 icon), after Career Framework

## Tests
- **9 tests** — `competency.snapshot.test.ts`: aggregation logic, deduplication, sorting, error handling, edge cases
- **14 tests** — `team-competency-prompt.test.ts`: prompt content, area rendering, empty state, 15-area cap

All 457 tests pass.

## Acceptance criteria
- [x] Aggregate competency query returns correct counts per area
- [x] AI narrative generated from aggregate data (no individual names)
- [x] Chart shows areas ranked by gap severity
- [x] Filter by team works correctly
- [x] Empty state when no assessments exist

