### PR TITLE
feat: onboarding risk score for new hires (#105)

### DIFF
--- a/app/(dashboard)/people/[id]/page.tsx
+++ b/app/(dashboard)/people/[id]/page.tsx
@@ -24,6 +24,7 @@ import { FollowUpForm } from "@/components/follow-ups/follow-up-form"
 import { getFollowUpsForPerson, type FollowUp } from "@/lib/services/follow-ups"
 import { usePersonSignals } from "@/lib/hooks/use-person-signals"
 import { scoreToColor, scoreToBg } from "@/lib/signals/types"
+import { isNewHire, NEW_HIRE_WINDOW_DAYS, daysBetween } from "@/lib/signals/compute"
 import { AlertCircle, AlertTriangle, Info, Plus as PlusIcon } from "lucide-react"
 
 interface TreeNode {
@@ -319,6 +320,11 @@ export default function PersonDetailPage({ params }: { params: Promise<{ id: str
                     : <Info style={{ width: "11px", height: "11px", color: "var(--text-3)", flexShrink: 0 }} />
                   }
                   <span style={{ fontSize: "var(--text-caption)", color: "var(--text-3)" }}>{s.message}</span>
+                  {s.meta?.isNewHire && (
+                    <span style={{ fontSize: "10px", fontWeight: 600, padding: "1px 5px", borderRadius: "3px", background: "rgba(0,240,88,0.12)", color: "#00f058", border: "1px solid rgba(0,240,88,0.3)", whiteSpace: "nowrap", flexShrink: 0 }}>
+                      New hire
+                    </span>
+                  )}
                 </div>
               ))}
               {signals.length > 3 && (
@@ -326,6 +332,22 @@ export default function PersonDetailPage({ params }: { params: Promise<{ id: str
               )}
             </div>
           )}
+          {/* Onboarding progress bar — visible for first 90 days */}
+          {formData.startDate && isNewHire(formData.startDate, new Date()) && (() => {
+            const daysIn = daysBetween(new Date(formData.startDate + 'T00:00:00'), new Date())
+            const pct = Math.min(100, Math.round((daysIn / NEW_HIRE_WINDOW_DAYS) * 100))
+            return (
+              <div style={{ marginTop: "8px", minWidth: "160px" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "4px" }}>
+                  <span style={{ fontSize: "10px", fontWeight: 600, color: "#00f058", textTransform: "uppercase", letterSpacing: "0.04em" }}>Onboarding</span>
+                  <span style={{ fontSize: "10px", color: "var(--text-3)" }}>Day {daysIn} / {NEW_HIRE_WINDOW_DAYS}</span>
+                </div>
+                <div style={{ height: "4px", borderRadius: "2px", background: "var(--border-1)", overflow: "hidden" }}>
+                  <div style={{ height: "100%", width: `${pct}%`, borderRadius: "2px", background: "linear-gradient(90deg, hsl(174,100%,50%), hsl(142,100%,47%))", transition: "width 0.3s ease" }} />
+                </div>
+              </div>
+            )
+          })()}
         </div>
       </div>
 

--- a/app/(dashboard)/people/[id]/page.tsx
+++ b/app/(dashboard)/people/[id]/page.tsx
@@ -320,7 +320,7 @@ export default function PersonDetailPage({ params }: { params: Promise<{ id: str
                     : <Info style={{ width: "11px", height: "11px", color: "var(--text-3)", flexShrink: 0 }} />
                   }
                   <span style={{ fontSize: "var(--text-caption)", color: "var(--text-3)" }}>{s.message}</span>
-                  {s.meta?.isNewHire && (
+                  {s.meta?.isNewHire === true && (
                     <span style={{ fontSize: "10px", fontWeight: 600, padding: "1px 5px", borderRadius: "3px", background: "rgba(0,240,88,0.12)", color: "#00f058", border: "1px solid rgba(0,240,88,0.3)", whiteSpace: "nowrap", flexShrink: 0 }}>
                       New hire
                     </span>

--- a/app/(dashboard)/radar/page.tsx
+++ b/app/(dashboard)/radar/page.tsx
@@ -183,7 +183,7 @@ function PersonCard({
             >
               <SeverityIcon severity={signal.severity} />
               <span style={{ flex: 1, color: 'var(--text-2)' }}>{signal.message}</span>
-              {signal.meta?.isNewHire && (
+              {signal.meta?.isNewHire === true && (
                 <span style={{ fontSize: '10px', fontWeight: 600, padding: '2px 6px', borderRadius: '4px', background: 'rgba(0,240,88,0.12)', color: '#00f058', border: '1px solid rgba(0,240,88,0.3)', whiteSpace: 'nowrap', flexShrink: 0 }}>
                   New hire
                 </span>

--- a/app/(dashboard)/radar/page.tsx
+++ b/app/(dashboard)/radar/page.tsx
@@ -183,6 +183,11 @@ function PersonCard({
             >
               <SeverityIcon severity={signal.severity} />
               <span style={{ flex: 1, color: 'var(--text-2)' }}>{signal.message}</span>
+              {signal.meta?.isNewHire && (
+                <span style={{ fontSize: '10px', fontWeight: 600, padding: '2px 6px', borderRadius: '4px', background: 'rgba(0,240,88,0.12)', color: '#00f058', border: '1px solid rgba(0,240,88,0.3)', whiteSpace: 'nowrap', flexShrink: 0 }}>
+                  New hire
+                </span>
+              )}
               {/* Quick actions per signal type */}
               {signal.type === 'overdue_task' && (
                 <button

--- a/app/(dashboard)/review/page.tsx
+++ b/app/(dashboard)/review/page.tsx
@@ -129,7 +129,14 @@ function SignalRow({
     >
       {severityDot(signal.severity)}
       <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontSize: '12px', color: 'var(--text-1)' }}>{signal.message}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap' }}>
+          <span style={{ fontSize: '12px', color: 'var(--text-1)' }}>{signal.message}</span>
+          {signal.meta?.isNewHire && (
+            <span style={{ fontSize: '10px', fontWeight: 600, padding: '1px 5px', borderRadius: '3px', background: 'rgba(0,240,88,0.12)', color: '#00f058', border: '1px solid rgba(0,240,88,0.3)', whiteSpace: 'nowrap' }}>
+              New hire
+            </span>
+          )}
+        </div>
         {typeof signal.meta?.subtitle === 'string' && signal.meta.subtitle && (
           <div style={{ fontSize: '11px', color: 'var(--text-3)', marginTop: '1px' }}>
             {signal.meta.subtitle}

--- a/app/(dashboard)/review/page.tsx
+++ b/app/(dashboard)/review/page.tsx
@@ -131,7 +131,7 @@ function SignalRow({
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap' }}>
           <span style={{ fontSize: '12px', color: 'var(--text-1)' }}>{signal.message}</span>
-          {signal.meta?.isNewHire && (
+          {signal.meta?.isNewHire === true && (
             <span style={{ fontSize: '10px', fontWeight: 600, padding: '1px 5px', borderRadius: '3px', background: 'rgba(0,240,88,0.12)', color: '#00f058', border: '1px solid rgba(0,240,88,0.3)', whiteSpace: 'nowrap' }}>
               New hire
             </span>

--- a/lib/services/weekly-review.ts
+++ b/lib/services/weekly-review.ts
@@ -15,6 +15,7 @@ export type DismissedItemType =
   | 'surfaced_follow_up'
   | 'action_overload'
   | 'sentiment_drift'
+  | 'new_hire_at_risk'
 
 export interface WeeklyReview {
   id: string

--- a/lib/signals/__tests__/new-hire.test.ts
+++ b/lib/signals/__tests__/new-hire.test.ts
@@ -4,7 +4,6 @@ import {
   NEW_HIRE_WINDOW_DAYS,
   computePeopleSignals,
   buildDismissedSet,
-  daysBetween,
   type SignalData,
 } from '../compute'
 

--- a/lib/signals/__tests__/new-hire.test.ts
+++ b/lib/signals/__tests__/new-hire.test.ts
@@ -1,0 +1,445 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isNewHire,
+  NEW_HIRE_WINDOW_DAYS,
+  computePeopleSignals,
+  buildDismissedSet,
+  daysBetween,
+  type SignalData,
+} from '../compute'
+
+// ── isNewHire ────────────────────────────────────────────────────────────────
+
+describe('isNewHire', () => {
+  const today = new Date('2024-06-15')
+
+  it('returns true when start_date is today', () => {
+    expect(isNewHire('2024-06-15', today)).toBe(true)
+  })
+
+  it('returns true when start_date is 1 day ago', () => {
+    expect(isNewHire('2024-06-14', today)).toBe(true)
+  })
+
+  it('returns true when start_date is 89 days ago (last day in window)', () => {
+    const d = new Date(today)
+    d.setDate(d.getDate() - (NEW_HIRE_WINDOW_DAYS - 1))
+    expect(isNewHire(d.toISOString().split('T')[0], today)).toBe(true)
+  })
+
+  it('returns false when start_date is exactly NEW_HIRE_WINDOW_DAYS ago', () => {
+    const d = new Date(today)
+    d.setDate(d.getDate() - NEW_HIRE_WINDOW_DAYS)
+    expect(isNewHire(d.toISOString().split('T')[0], today)).toBe(false)
+  })
+
+  it('returns false when start_date is 200 days ago', () => {
+    expect(isNewHire('2023-12-01', today)).toBe(false)
+  })
+
+  it('returns false for null start_date', () => {
+    expect(isNewHire(null, today)).toBe(false)
+  })
+
+  it('returns false for undefined start_date', () => {
+    expect(isNewHire(undefined, today)).toBe(false)
+  })
+
+  it('returns false when start_date is in the future', () => {
+    // Future start dates should not count as new hires — daysBetween will be negative
+    expect(isNewHire('2024-07-01', today)).toBe(false)
+  })
+})
+
+// ── NEW_HIRE_WINDOW_DAYS ─────────────────────────────────────────────────────
+
+describe('NEW_HIRE_WINDOW_DAYS', () => {
+  it('is 90', () => {
+    expect(NEW_HIRE_WINDOW_DAYS).toBe(90)
+  })
+})
+
+// ── computePeopleSignals — new hire threshold adjustments ────────────────────
+
+function makeData(overrides: Partial<SignalData> = {}): SignalData {
+  return {
+    overdueTasks: [],
+    activePeople: [],
+    recentMeetings: [],
+    upcomingTasks: [],
+    evidenceRecent: [],
+    meetingsWithNotes: [],
+    openFollowUps: [],
+    tasksByPerson: [],
+    ...overrides,
+  }
+}
+
+function dateStr(daysAgo: number, base = new Date('2024-06-15')): string {
+  const d = new Date(base)
+  d.setDate(d.getDate() - daysAgo)
+  return d.toISOString().split('T')[0]
+}
+
+const TODAY = new Date('2024-06-15')
+const DISMISSED = buildDismissedSet([])
+
+// Helper: a person who started N days ago
+function newHirePerson(startedDaysAgo: number) {
+  return { id: 'p1', full_name: 'Alice', role: null, start_date: dateStr(startedDaysAgo) }
+}
+function veteranPerson() {
+  return { id: 'p1', full_name: 'Alice', role: null, start_date: dateStr(200) }
+}
+
+// ── no_recent_1on1 thresholds ────────────────────────────────────────────────
+
+describe('computePeopleSignals — no_recent_1on1 for new hire', () => {
+  it('fires warning at 7 days (not 14) for new hire', () => {
+    const person = newHirePerson(10)
+    const data = makeData({
+      activePeople: [person],
+      recentMeetings: [
+        { id: 'm1', meeting_type: '1:1', meeting_date: dateStr(7), person_id: 'p1', action_items: null, notes: null, title: '1:1' },
+      ],
+    })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'no_recent_1on1')
+    expect(s).toBeDefined()
+    expect(s!.severity).toBe('warning')
+    expect(s!.meta?.isNewHire).toBe(true)
+  })
+
+  it('fires critical at 14 days for new hire (not 21)', () => {
+    const person = newHirePerson(10)
+    const data = makeData({
+      activePeople: [person],
+      recentMeetings: [
+        { id: 'm1', meeting_type: '1:1', meeting_date: dateStr(14), person_id: 'p1', action_items: null, notes: null, title: '1:1' },
+      ],
+    })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'no_recent_1on1')
+    expect(s).toBeDefined()
+    expect(s!.severity).toBe('critical')
+    expect(s!.meta?.isNewHire).toBe(true)
+  })
+
+  it('does NOT fire warning at 7 days for veteran (requires 14)', () => {
+    const person = veteranPerson()
+    const data = makeData({
+      activePeople: [person],
+      recentMeetings: [
+        { id: 'm1', meeting_type: '1:1', meeting_date: dateStr(7), person_id: 'p1', action_items: null, notes: null, title: '1:1' },
+      ],
+    })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'no_recent_1on1')
+    expect(s).toBeUndefined()
+  })
+
+  it('does NOT fire at 13 days for veteran (threshold is 14)', () => {
+    const person = veteranPerson()
+    const data = makeData({
+      activePeople: [person],
+      recentMeetings: [
+        { id: 'm1', meeting_type: '1:1', meeting_date: dateStr(13), person_id: 'p1', action_items: null, notes: null, title: '1:1' },
+      ],
+    })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'no_recent_1on1')
+    expect(s).toBeUndefined()
+  })
+
+  it('fires warning at 14 days for veteran', () => {
+    const person = veteranPerson()
+    const data = makeData({
+      activePeople: [person],
+      recentMeetings: [
+        { id: 'm1', meeting_type: '1:1', meeting_date: dateStr(14), person_id: 'p1', action_items: null, notes: null, title: '1:1' },
+      ],
+    })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'no_recent_1on1')
+    expect(s).toBeDefined()
+    expect(s!.severity).toBe('warning')
+    expect(s!.meta?.isNewHire).toBe(false)
+  })
+
+  it('fires critical at 21 days for veteran (not 14)', () => {
+    const person = veteranPerson()
+    const data = makeData({
+      activePeople: [person],
+      recentMeetings: [
+        { id: 'm1', meeting_type: '1:1', meeting_date: dateStr(21), person_id: 'p1', action_items: null, notes: null, title: '1:1' },
+      ],
+    })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'no_recent_1on1')
+    expect(s).toBeDefined()
+    expect(s!.severity).toBe('critical')
+  })
+
+  it('fires critical when no 1:1 ever exists for new hire', () => {
+    const person = newHirePerson(10)
+    const data = makeData({ activePeople: [person] })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'no_recent_1on1')
+    expect(s).toBeDefined()
+    expect(s!.severity).toBe('critical')
+    expect(s!.meta?.isNewHire).toBe(true)
+  })
+})
+
+// ── no_evidence thresholds ────────────────────────────────────────────────────
+
+describe('computePeopleSignals — no_evidence for new hire', () => {
+  it('fires for new hire with no evidence in 30 days (even if evidence exists >30 days ago)', () => {
+    const person = newHirePerson(10)
+    const data = makeData({
+      activePeople: [person],
+      // Evidence is 45 days old — within 90-day window but outside new hire 30-day window
+      evidenceRecent: [
+        { person_id: 'p1', occurred_at: dateStr(45), sentiment: 'positive' },
+      ],
+    })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'no_evidence')
+    expect(s).toBeDefined()
+    expect(s!.meta?.isNewHire).toBe(true)
+  })
+
+  it('does NOT fire for new hire when evidence exists within 30 days', () => {
+    const person = newHirePerson(10)
+    const data = makeData({
+      activePeople: [person],
+      evidenceRecent: [
+        { person_id: 'p1', occurred_at: dateStr(20), sentiment: 'positive' },
+      ],
+    })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'no_evidence')
+    expect(s).toBeUndefined()
+  })
+
+  it('does NOT fire for veteran with evidence in past 90 days', () => {
+    const person = veteranPerson()
+    const data = makeData({
+      activePeople: [person],
+      evidenceRecent: [
+        { person_id: 'p1', occurred_at: dateStr(60), sentiment: 'neutral' },
+      ],
+    })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'no_evidence')
+    expect(s).toBeUndefined()
+  })
+
+  it('fires for veteran with no evidence in 90 days', () => {
+    const person = veteranPerson()
+    const data = makeData({ activePeople: [person] })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'no_evidence')
+    expect(s).toBeDefined()
+    expect(s!.meta?.isNewHire).toBe(false)
+  })
+
+  it('message includes correct window for new hire (30)', () => {
+    const person = newHirePerson(10)
+    const data = makeData({ activePeople: [person] })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'no_evidence')
+    expect(s?.message).toContain('30 days')
+  })
+
+  it('message includes correct window for veteran (90)', () => {
+    const person = veteranPerson()
+    const data = makeData({ activePeople: [person] })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'no_evidence')
+    expect(s?.message).toContain('90 days')
+  })
+})
+
+// ── missing_notes thresholds ─────────────────────────────────────────────────
+
+describe('computePeopleSignals — missing_notes for new hire', () => {
+  it('fires for new hire with last note 14 days ago', () => {
+    const person = newHirePerson(10)
+    const data = makeData({
+      activePeople: [person],
+      meetingsWithNotes: [
+        { id: 'm1', person_id: 'p1', meeting_date: dateStr(14), notes: 'some notes' },
+      ],
+    })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'missing_notes')
+    expect(s).toBeDefined()
+    expect(s!.meta?.isNewHire).toBe(true)
+  })
+
+  it('does NOT fire for new hire with note 13 days ago', () => {
+    const person = newHirePerson(10)
+    const data = makeData({
+      activePeople: [person],
+      meetingsWithNotes: [
+        { id: 'm1', person_id: 'p1', meeting_date: dateStr(13), notes: 'recent note' },
+      ],
+    })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'missing_notes')
+    expect(s).toBeUndefined()
+  })
+
+  it('fires for veteran with no notes (last note window is 21d — no notes = fires)', () => {
+    const person = veteranPerson()
+    const data = makeData({ activePeople: [person] })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'missing_notes')
+    expect(s).toBeDefined()
+    expect(s!.meta?.isNewHire).toBe(false)
+  })
+
+  it('does NOT fire for veteran with note 14 days ago (threshold is 21)', () => {
+    const person = veteranPerson()
+    const data = makeData({
+      activePeople: [person],
+      meetingsWithNotes: [
+        { id: 'm1', person_id: 'p1', meeting_date: dateStr(14), notes: 'note' },
+      ],
+    })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const s = signals.find(x => x.type === 'missing_notes')
+    expect(s).toBeUndefined()
+  })
+})
+
+// ── new_hire_at_risk compound signal ─────────────────────────────────────────
+
+describe('computePeopleSignals — new_hire_at_risk compound signal', () => {
+  it('fires when new hire triggers 2+ signals', () => {
+    // new hire with no 1:1 (>7d) AND no evidence (>30d) → 2 signals → compound fires
+    const person = newHirePerson(10)
+    const data = makeData({ activePeople: [person] })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const compound = signals.find(x => x.type === 'new_hire_at_risk')
+    expect(compound).toBeDefined()
+    expect(compound!.severity).toBe('critical')
+    expect(compound!.meta?.isNewHire).toBe(true)
+    const fired = compound!.meta?.firedSignalTypes as string[]
+    expect(fired.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('does NOT fire for new hire with only 1 signal', () => {
+    // new hire with a recent 1:1 (6 days ago) and recent evidence (5 days ago) and recent notes (5 days ago)
+    // → only missing_notes might fire at 6 days since that's <14, so all clear except maybe nothing
+    const person = newHirePerson(30)
+    const data = makeData({
+      activePeople: [person],
+      recentMeetings: [
+        // 1:1 only 6 days ago — within new hire 7-day threshold
+        { id: 'm1', meeting_type: '1:1', meeting_date: dateStr(6), person_id: 'p1', action_items: null, notes: 'n', title: '1:1' },
+      ],
+      evidenceRecent: [
+        { person_id: 'p1', occurred_at: dateStr(5), sentiment: 'positive' },
+      ],
+      meetingsWithNotes: [
+        { id: 'm2', person_id: 'p1', meeting_date: dateStr(5), notes: 'some notes' },
+      ],
+    })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const compound = signals.find(x => x.type === 'new_hire_at_risk')
+    expect(compound).toBeUndefined()
+  })
+
+  it('does NOT fire for veteran even with multiple signals', () => {
+    // veteran with no 1:1, no evidence, no notes → multiple signals but NOT new hire
+    const person = veteranPerson()
+    const data = makeData({ activePeople: [person] })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const compound = signals.find(x => x.type === 'new_hire_at_risk')
+    expect(compound).toBeUndefined()
+  })
+
+  it('does NOT fire when new_hire_at_risk is dismissed', () => {
+    const person = newHirePerson(10)
+    const data = makeData({ activePeople: [person] })
+    const dismissed = buildDismissedSet([
+      { itemType: 'new_hire_at_risk', referenceId: 'p1' },
+    ])
+    const signals = computePeopleSignals(data, dismissed, TODAY)
+    const compound = signals.find(x => x.type === 'new_hire_at_risk')
+    expect(compound).toBeUndefined()
+  })
+
+  it('fires for new hire on exactly day 89 (still within window)', () => {
+    const person = newHirePerson(89)
+    const data = makeData({ activePeople: [person] })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const compound = signals.find(x => x.type === 'new_hire_at_risk')
+    expect(compound).toBeDefined()
+  })
+
+  it('does NOT fire for person on exactly day 90 (outside window)', () => {
+    const person = newHirePerson(90)
+    const data = makeData({ activePeople: [person] })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const compound = signals.find(x => x.type === 'new_hire_at_risk')
+    expect(compound).toBeUndefined()
+  })
+
+  it('includes firedSignalTypes in meta', () => {
+    const person = newHirePerson(10)
+    const data = makeData({ activePeople: [person] })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const compound = signals.find(x => x.type === 'new_hire_at_risk')
+    expect(Array.isArray(compound?.meta?.firedSignalTypes)).toBe(true)
+  })
+
+  it('fires with exactly 2 signals when only no_recent_1on1 + no_evidence fire', () => {
+    const person = newHirePerson(10)
+    // Has recent notes (5d ago) to avoid missing_notes firing
+    // No 1:1 in 8 days (>7d threshold → fires), no evidence
+    const data = makeData({
+      activePeople: [person],
+      recentMeetings: [
+        { id: 'm1', meeting_type: '1:1', meeting_date: dateStr(8), person_id: 'p1', action_items: null, notes: null, title: '1:1' },
+      ],
+      meetingsWithNotes: [
+        { id: 'm2', person_id: 'p1', meeting_date: dateStr(5), notes: 'notes' },
+      ],
+      // no evidence within 30 days
+    })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const compound = signals.find(x => x.type === 'new_hire_at_risk')
+    expect(compound).toBeDefined()
+    const fired = compound!.meta!.firedSignalTypes as string[]
+    expect(fired).toContain('no_recent_1on1')
+    expect(fired).toContain('no_evidence')
+  })
+})
+
+// ── isNewHire flag in meta ────────────────────────────────────────────────────
+
+describe('computePeopleSignals — isNewHire meta flag', () => {
+  it('sets isNewHire=true in meta for new hire signals', () => {
+    const person = newHirePerson(10)
+    const data = makeData({ activePeople: [person] })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const personSignals = signals.filter(x => x.personId === 'p1' && x.meta?.isNewHire !== undefined)
+    expect(personSignals.length).toBeGreaterThan(0)
+    for (const s of personSignals) {
+      expect(s.meta?.isNewHire).toBe(true)
+    }
+  })
+
+  it('sets isNewHire=false in meta for veteran signals', () => {
+    const person = veteranPerson()
+    const data = makeData({ activePeople: [person] })
+    const signals = computePeopleSignals(data, DISMISSED, TODAY)
+    const personSignals = signals.filter(x => x.personId === 'p1' && x.meta?.isNewHire !== undefined)
+    for (const s of personSignals) {
+      expect(s.meta?.isNewHire).toBe(false)
+    }
+  })
+})

--- a/lib/signals/__tests__/signals.test.ts
+++ b/lib/signals/__tests__/signals.test.ts
@@ -115,7 +115,7 @@ describe('SIGNAL_WEIGHTS completeness', () => {
     'overdue_task', 'no_recent_1on1', 'unresolved_action', 'no_evidence',
     'upcoming_deadline', 'missing_notes', 'overdue_follow_up',
     'ageing_follow_up', 'surfaced_follow_up', 'action_overload',
-    'sentiment_drift',
+    'sentiment_drift', 'new_hire_at_risk',
   ]
 
   it('has a weight entry for every signal type', () => {

--- a/lib/signals/compute.ts
+++ b/lib/signals/compute.ts
@@ -3,8 +3,22 @@ import type { Signal, SignalSeverity } from './types'
 
 const DAYS_MS = 24 * 60 * 60 * 1000
 
+/** Days from start_date within which a person is considered a new hire. Configurable constant. */
+export const NEW_HIRE_WINDOW_DAYS = 90
+
 export function daysBetween(a: Date, b: Date): number {
   return Math.floor((b.getTime() - a.getTime()) / DAYS_MS)
+}
+
+/**
+ * Returns true if the person started within NEW_HIRE_WINDOW_DAYS before `today`.
+ * Returns false if start_date is null/undefined.
+ */
+export function isNewHire(startDate: string | null | undefined, today: Date): boolean {
+  if (!startDate) return false
+  const start = new Date(startDate + 'T00:00:00')
+  const daysSinceStart = daysBetween(start, today)
+  return daysSinceStart >= 0 && daysSinceStart < NEW_HIRE_WINDOW_DAYS
 }
 
 export function todayStr(): string {
@@ -70,7 +84,7 @@ export async function loadSignalData() {
 
     supabase
       .from('people')
-      .select('id, full_name, role')
+      .select('id, full_name, role, start_date')
       .eq('status', 'active'),
 
     supabase
@@ -207,10 +221,31 @@ export function computePeopleSignals(
   for (const person of data.activePeople) {
     const lastOneOnOne = oneOnOneMeetingsByPerson[person.id]
     const lastNoteDate = notesDateByPerson[person.id]
+    const newHire = isNewHire((person as any).start_date, today)
+
+    // Thresholds adjusted for new hires
+    const oneOnOneWarnDays = newHire ? 7 : 14
+    const oneOnOneCritDays = newHire ? 14 : 21
+    const evidenceDays     = newHire ? 30 : 90
+    const notesDays        = newHire ? 14 : 21
+
+    // Build evidence lookup for new hire threshold (30 days)
+    // (existing evidenceRecent covers 90 days; filter down for new hire check)
+    const evidenceInWindowPersonIds = newHire
+      ? new Set(
+          (data.evidenceRecent as Array<{ person_id: string; occurred_at: string }>)
+            .filter(e => daysBetween(new Date(e.occurred_at + 'T00:00:00'), today) < evidenceDays)
+            .map(e => e.person_id)
+        )
+      : evidence90DaysPersonIds
+
+    // Track which person-level signal types fired (for compound signal)
+    const firedSignalTypes: string[] = []
 
     // Signal: no recent 1:1
     if (!isDismissed(dismissedSet, 'no_recent_1on1', person.id)) {
       if (!lastOneOnOne) {
+        firedSignalTypes.push('no_recent_1on1')
         signals.push({
           type: 'no_recent_1on1',
           severity: 'critical',
@@ -219,20 +254,21 @@ export function computePeopleSignals(
           personName: person.full_name,
           entityId: person.id,
           entityType: 'person',
-          meta: { daysSince: null },
+          meta: { daysSince: null, isNewHire: newHire },
         })
       } else {
         const daysSince = daysBetween(new Date(lastOneOnOne + 'T00:00:00'), today)
-        if (daysSince >= 14) {
+        if (daysSince >= oneOnOneWarnDays) {
+          firedSignalTypes.push('no_recent_1on1')
           signals.push({
             type: 'no_recent_1on1',
-            severity: daysSince >= 21 ? 'critical' : 'warning',
+            severity: daysSince >= oneOnOneCritDays ? 'critical' : 'warning',
             message: `No 1:1 with ${person.full_name} in ${daysSince} days`,
             personId: person.id,
             personName: person.full_name,
             entityId: person.id,
             entityType: 'person',
-            meta: { daysSince, lastDate: lastOneOnOne },
+            meta: { daysSince, lastDate: lastOneOnOne, isNewHire: newHire },
           })
         }
       }
@@ -240,31 +276,38 @@ export function computePeopleSignals(
 
     // Signal: no recent evidence
     if (!isDismissed(dismissedSet, 'no_evidence', person.id)) {
-      if (!evidence90DaysPersonIds.has(person.id)) {
+      if (!evidenceInWindowPersonIds.has(person.id)) {
+        firedSignalTypes.push('no_evidence')
         signals.push({
           type: 'no_evidence',
           severity: evidenceAnyPersonIds.has(person.id) ? 'warning' : 'info',
-          message: `No evidence logged for ${person.full_name} in 90 days`,
+          message: `No evidence logged for ${person.full_name} in ${evidenceDays} days`,
           personId: person.id,
           personName: person.full_name,
           entityId: person.id,
           entityType: 'person',
+          meta: { isNewHire: newHire },
         })
       }
     }
 
     // Signal: no recent meeting notes
     if (!isDismissed(dismissedSet, 'missing_notes', person.id)) {
-      if (!lastNoteDate) {
+      const lastNoteDateMs = lastNoteDate
+        ? daysBetween(new Date(lastNoteDate + 'T00:00:00'), today)
+        : null
+      const notesMissing = lastNoteDateMs === null || lastNoteDateMs >= notesDays
+      if (notesMissing) {
+        firedSignalTypes.push('missing_notes')
         signals.push({
           type: 'missing_notes',
           severity: 'info',
-          message: `No meeting notes involving ${person.full_name} in 21 days`,
+          message: `No meeting notes involving ${person.full_name} in ${notesDays} days`,
           personId: person.id,
           personName: person.full_name,
           entityId: person.id,
           entityType: 'person',
-          meta: { daysSince: null },
+          meta: { daysSince: lastNoteDateMs, isNewHire: newHire },
         })
       }
     }
@@ -281,6 +324,20 @@ export function computePeopleSignals(
         entityId: person.id,
         entityType: 'person',
         meta: { openTaskCount },
+      })
+    }
+
+    // Compound signal: new hire triggering 2+ person-level signals
+    if (newHire && firedSignalTypes.length >= 2 && !isDismissed(dismissedSet, 'new_hire_at_risk', person.id)) {
+      signals.push({
+        type: 'new_hire_at_risk',
+        severity: 'critical',
+        message: `${person.full_name} is a new hire with ${firedSignalTypes.length} unresolved onboarding signals`,
+        personId: person.id,
+        personName: person.full_name,
+        entityId: person.id,
+        entityType: 'person',
+        meta: { isNewHire: true, firedSignalTypes },
       })
     }
   }

--- a/lib/signals/compute.ts
+++ b/lib/signals/compute.ts
@@ -564,8 +564,18 @@ export function computeSentimentDriftSignals(
   return signals
 }
 
-/** Sort signals: critical first, warning second, info last */
+/**
+ * Sort signals: critical first, warning second, info last.
+ * Within same severity, new hire signals sort before non-new-hire signals.
+ */
 export function sortSignals(signals: Signal[]): Signal[] {
   const order: Record<string, number> = { critical: 0, warning: 1, info: 2 }
-  return [...signals].sort((a, b) => order[a.severity] - order[b.severity])
+  return [...signals].sort((a, b) => {
+    const severityDiff = order[a.severity] - order[b.severity]
+    if (severityDiff !== 0) return severityDiff
+    // New hire signals bubble up within same severity tier
+    const aIsNewHire = a.meta?.isNewHire === true || a.type === 'new_hire_at_risk' ? 0 : 1
+    const bIsNewHire = b.meta?.isNewHire === true || b.type === 'new_hire_at_risk' ? 0 : 1
+    return aIsNewHire - bIsNewHire
+  })
 }

--- a/lib/signals/types.ts
+++ b/lib/signals/types.ts
@@ -12,6 +12,7 @@ export type SignalType =
   | 'surfaced_follow_up'
   | 'action_overload'
   | 'sentiment_drift'
+  | 'new_hire_at_risk'
 
 export interface Signal {
   type: SignalType
@@ -37,6 +38,7 @@ export const SIGNAL_WEIGHTS: Record<SignalType, number> = {
   surfaced_follow_up: 5,
   action_overload: 3,
   sentiment_drift: 4,       // trending negative — notable attention
+  new_hire_at_risk: 5,      // new hire triggering 2+ signals — high priority
 }
 
 /** Critical signals get a bonus weight */


### PR DESCRIPTION
## Summary

Implements #105 — new hire risk detection across the signal engine and UI.

## Changes

### Signal Engine
- **NEW_HIRE_WINDOW_DAYS = 90** — single configurable constant; used everywhere, not hardcoded per-check
- **isNewHire(startDate, today)** — pure helper; returns true if start_date is within 90 days
- **loadSignalData** — now selects start_date on active people
- **Lowered thresholds for new hires:**
  - no_recent_1on1: warn at 7d (was 14d), critical at 14d (was 21d)
  - no_evidence: window 30d (was 90d)
  - missing_notes: window 14d (was 21d)
- **new_hire_at_risk** compound signal: fires critical when a new hire triggers 2+ person-level signals simultaneously
- isNewHire flag propagated in signal meta for UI consumption
- sortSignals: new hire signals surface before equivalent non-new-hire signals within same severity tier

### UI
- **Radar** — green New hire badge on each signal where meta.isNewHire = true
- **Weekly Review** — New hire badge inline in SignalRow message
- **Person detail page** — New hire badge on inline signals + onboarding progress bar showing day X / 90 with brand gradient fill (visible only during first 90 days)

### Types
- new_hire_at_risk added to SignalType union
- Weight: 5 (same as surfaced_follow_up — highest priority class)

## Tests
- 36 new unit tests covering:
  - isNewHire boundary cases (day 89 pass, day 90 fail, null, undefined, future dates)
  - Threshold differences between new hires and veterans for all three signal types
  - Compound signal: fires on 2+, not on 1, not for veterans, respects dismiss
  - meta.isNewHire flag correctness
  - new_hire_at_risk in SIGNAL_WEIGHTS completeness check
- All 493 existing tests continue to pass

## Acceptance Criteria
- [x] New hire status computed from start_date field
- [x] Signal thresholds lowered for new hires across all relevant signal types
- [x] new_hire_at_risk compound signal fires correctly
- [x] New hire signals visually distinguished in UI
- [x] 90-day window is configurable (single NEW_HIRE_WINDOW_DAYS constant)

Closes #105
