### PR TITLE
feat: stale career goal detection signal (#106)

### DIFF
--- a/app/(dashboard)/career-goals/page.tsx
+++ b/app/(dashboard)/career-goals/page.tsx
@@ -64,6 +64,8 @@ interface Goal {
   category: string
   categoryId: string
   status: "Not started" | "In progress" | "Completed"
+  /** ISO date string (YYYY-MM-DD) of last update — used for staleness badge */
+  updatedAt: string
 }
 
 interface AchievementRow {
@@ -180,6 +182,7 @@ export default function CareerGoalsPage() {
         category: g.category,
         categoryId: g.categoryId,
         status: g.status,
+        updatedAt: g.updatedAt.split('T')[0],
       })))
       setMidTermGoals(midGoals.map(g => ({
         id: g.id,
@@ -188,6 +191,7 @@ export default function CareerGoalsPage() {
         category: g.category,
         categoryId: g.categoryId,
         status: g.status,
+        updatedAt: g.updatedAt.split('T')[0],
       })))
       setLongTermGoals(longGoals.map(g => ({
         id: g.id,
@@ -196,6 +200,7 @@ export default function CareerGoalsPage() {
         category: g.category,
         categoryId: g.categoryId,
         status: g.status,
+        updatedAt: g.updatedAt.split('T')[0],
       })))
 
       // Load achievements
@@ -385,6 +390,7 @@ export default function CareerGoalsPage() {
         category: newGoal.category,
         categoryId: newGoal.categoryId,
         status: newGoal.status,
+        updatedAt: newGoal.updatedAt.split('T')[0],
       }])
     } catch (error) {
       console.error('Failed to create goal:', error)
@@ -399,9 +405,10 @@ export default function CareerGoalsPage() {
     field: keyof Goal,
     value: string
   ) => {
-    // Update local state immediately
+    // Update local state immediately (also bump updatedAt so staleness badge refreshes)
+    const todayISO = new Date().toISOString().split('T')[0]
     setter(goals.map(goal =>
-      goal.id === id ? { ...goal, [field]: value } : goal
+      goal.id === id ? { ...goal, [field]: value, updatedAt: todayISO } : goal
     ))
 
     // Update database
@@ -494,6 +501,36 @@ export default function CareerGoalsPage() {
     })
 
     return distribution
+  }
+
+  /** Returns staleness info for a goal: days since last update, and severity if stale. */
+  const getGoalStaleness = (updatedAt: string): { daysSince: number; severity: 'info' | 'warning' | 'critical' } | null => {
+    const today = new Date()
+    const last = new Date(updatedAt + 'T00:00:00')
+    const daysSince = Math.floor((today.getTime() - last.getTime()) / (24 * 60 * 60 * 1000))
+    if (daysSince < 60) return null
+    const severity = daysSince >= 120 ? 'critical' : daysSince >= 90 ? 'warning' : 'info'
+    return { daysSince, severity }
+  }
+
+  /** Renders a small staleness badge for stale goals. */
+  const stalenessBadge = (updatedAt: string, status: Goal['status']) => {
+    if (status === 'Completed') return null
+    const staleness = getGoalStaleness(updatedAt)
+    if (!staleness) return null
+    const { daysSince, severity } = staleness
+    const bg = severity === 'critical' ? '#2a0a0a' : severity === 'warning' ? '#2a1a08' : '#0c1a3d'
+    const color = severity === 'critical' ? '#f87171' : severity === 'warning' ? '#f97316' : '#60a5fa'
+    return (
+      <span title={`No activity in ${daysSince} days`} style={{
+        display: 'inline-flex', alignItems: 'center', gap: '3px',
+        background: bg, color, fontSize: '10px', fontFamily: 'var(--font-mono)',
+        fontWeight: 500, borderRadius: '3px', padding: '1px 5px',
+        marginLeft: '4px', verticalAlign: 'middle', cursor: 'default',
+      }}>
+        {daysSince}d stale
+      </span>
+    )
   }
 
   const getCategoryColor = (category: string) => {
@@ -849,6 +886,7 @@ export default function CareerGoalsPage() {
                               rows={2}
                               autoResize
                             />
+                            {stalenessBadge(goal.updatedAt, goal.status)}
                           </td>
                           <td className="p-2">
                             <BadgeSelect
@@ -1056,6 +1094,7 @@ export default function CareerGoalsPage() {
                               rows={2}
                               autoResize
                             />
+                            {stalenessBadge(goal.updatedAt, goal.status)}
                           </td>
                           <td className="p-2">
                             <BadgeSelect
@@ -1263,6 +1302,7 @@ export default function CareerGoalsPage() {
                               rows={2}
                               autoResize
                             />
+                            {stalenessBadge(goal.updatedAt, goal.status)}
                           </td>
                           <td className="p-2">
                             <BadgeSelect

--- a/app/(dashboard)/review/page.tsx
+++ b/app/(dashboard)/review/page.tsx
@@ -181,6 +181,13 @@ const ICON_REFLECTION = (
     <path d="M3 13V3a1 1 0 011-1h8a1 1 0 011 1v10l-5-3-5 3z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
   </svg>
 )
+const ICON_GOALS = (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <circle cx="8" cy="8" r="5.5" stroke="currentColor" strokeWidth="1.2" />
+    <circle cx="8" cy="8" r="2.5" stroke="currentColor" strokeWidth="1.2" />
+    <circle cx="8" cy="8" r="0.8" fill="currentColor" />
+  </svg>
+)
 const ICON_COMPLETE = (
   <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
     <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.2" />
@@ -204,6 +211,7 @@ export default function WeeklyReviewPage() {
     people: false,
     actions: false,
     tasks: false,
+    goals: false,
     week: false,
     reflection: false,
   })
@@ -380,18 +388,20 @@ export default function WeeklyReviewPage() {
   const taskSignals = signals.filter(s => s.type === 'overdue_task' || s.type === 'upcoming_deadline')
   const overdueSignals = taskSignals.filter(s => s.type === 'overdue_task')
   const upcomingSignals = taskSignals.filter(s => s.type === 'upcoming_deadline')
+  const goalSignals = signals.filter(s => s.type === 'stale_goal')
 
   // Sections auto-check when all their signals are cleared
   const effectiveSectionState = {
     people:     peopleSignals.length === 0 || sectionState.people,
     actions:    actionSignals.length === 0  || sectionState.actions,
     tasks:      taskSignals.length === 0    || sectionState.tasks,
+    goals:      goalSignals.length === 0    || sectionState.goals,
     week:       sectionState.week,
     reflection: sectionState.reflection,
   }
 
   // Progress = completed sections / 5 (week excluded — no action items)
-  const PROGRESS_SECTIONS = ['people', 'actions', 'tasks', 'reflection'] as const
+  const PROGRESS_SECTIONS = ['people', 'actions', 'tasks', 'goals', 'reflection'] as const
   const reviewedCount = PROGRESS_SECTIONS.filter(k => effectiveSectionState[k]).length
   const progressPct = Math.round((reviewedCount / PROGRESS_SECTIONS.length) * 100)
 
@@ -759,7 +769,61 @@ export default function WeeklyReviewPage() {
             ) : null}
           </ReviewSection>
 
-          {/* Section 4: Week in Review */}
+          {/* Section 4: Career Goal Staleness */}
+          <ReviewSection
+            title="Career Goal Staleness"
+            icon={ICON_GOALS}
+            signalCount={isReadOnly ? 0 : goalSignals.length}
+            criticalCount={isReadOnly ? 0 : goalSignals.filter(s => s.severity === 'critical').length}
+            warningCount={isReadOnly ? 0 : goalSignals.filter(s => s.severity === 'warning').length}
+            infoCount={isReadOnly ? 0 : goalSignals.filter(s => s.severity === 'info').length}
+            isReviewed={effectiveSectionState.goals}
+            onMarkReviewed={() => toggleSection('goals')}
+            emptyMessage="All career goals have recent activity"
+          >
+            {!isReadOnly && goalSignals.length > 0 ? (
+              <>
+                {goalSignals.map((s, i) => {
+                  const daysSince = s.meta?.daysSince as number | undefined
+                  const timePeriod = s.meta?.timePeriod as string | undefined
+                  const periodLabel =
+                    timePeriod === 'short_term' ? 'Short-term'
+                    : timePeriod === 'mid_term' ? 'Mid-term'
+                    : timePeriod === 'long_term' ? 'Long-term'
+                    : null
+                  const subtitle = [
+                    periodLabel,
+                    daysSince != null ? `No activity in ${daysSince} day${daysSince === 1 ? '' : 's'}` : null,
+                  ].filter(Boolean).join(' · ')
+                  const goalTitle = s.message.match(/"([^"]+)"/)?.[1] ?? s.message
+                  return (
+                    <div
+                      key={i}
+                      style={{ display: 'flex', alignItems: 'flex-start', gap: '10px', padding: '10px 16px', borderBottom: i < goalSignals.length - 1 ? '1px solid var(--border-1)' : 'none' }}
+                      onMouseEnter={e => (e.currentTarget.style.background = 'var(--surf-2)')}
+                      onMouseLeave={e => (e.currentTarget.style.background = '')}
+                    >
+                      {severityDot(s.severity)}
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ fontSize: '12px', color: 'var(--text-1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {goalTitle}
+                        </div>
+                        <div style={{ fontSize: '11px', color: 'var(--text-3)', marginTop: '1px' }}>{subtitle}</div>
+                      </div>
+                      <div style={{ display: 'flex', gap: '4px', flexShrink: 0 }}>
+                        <Btn variant="primary" onClick={() => router.push('/career-goals')}>
+                          Update goal
+                        </Btn>
+                        <Btn variant="dismiss" onClick={() => setDismissTarget(s)}>Dismiss</Btn>
+                      </div>
+                    </div>
+                  )
+                })}
+              </>
+            ) : null}
+          </ReviewSection>
+
+          {/* Section 5: Week in Review */}
           <ReviewSection
             title="Week in Review"
             icon={ICON_WEEK}
@@ -796,7 +860,7 @@ export default function WeeklyReviewPage() {
             )}
           </ReviewSection>
 
-          {/* Section 5: Reflection */}
+          {/* Section 6: Reflection */}
           <ReviewSection
             title="Reflection"
             icon={ICON_REFLECTION}
@@ -871,7 +935,7 @@ export default function WeeklyReviewPage() {
             </div>
           </ReviewSection>
 
-          {/* Section 6: Complete Review */}
+          {/* Section 7: Complete Review */}
           {isCurrentWeek && (
             <ReviewSection
               title="Complete Review"

--- a/lib/hooks/use-weekly-review-signals.ts
+++ b/lib/hooks/use-weekly-review-signals.ts
@@ -8,6 +8,7 @@ import {
   computeFollowUpSignals,
   computeActionItemSignals,
   computeSentimentDriftSignals,
+  computeGoalSignals,
   sortSignals,
   buildDismissedSet,
 } from '@/lib/signals/compute'
@@ -52,8 +53,9 @@ async function computeAllSignals(dismissedItems: DismissedItem[]): Promise<Signa
     dismissedSet,
     today
   )
+  const goalSignals = computeGoalSignals(data.careerGoals, dismissedSet, today)
 
-  return sortSignals([...taskSignals, ...peopleSignals, ...actionSignals, ...followUpSignals, ...sentimentDriftSignals])
+  return sortSignals([...taskSignals, ...peopleSignals, ...actionSignals, ...followUpSignals, ...sentimentDriftSignals, ...goalSignals])
 }
 
 export function useWeeklyReviewSignals(dismissedItems: DismissedItem[]): SignalsData {

--- a/lib/services/__tests__/career-goals.test.ts
+++ b/lib/services/__tests__/career-goals.test.ts
@@ -13,6 +13,7 @@ import {
   deleteCareerGoal,
   getAchievements,
   createAchievement,
+  getGoalsWithLastEvidenceDate,
 } from '../career-goals'
 import { mockSupabaseClient } from '../../../test/mocks/supabase'
 
@@ -479,6 +480,150 @@ describe('Career Goals Service', () => {
       await expect(
         createAchievement({ type: 'Book', description: '', achievementDate: '', keyTakeaway: '' })
       ).rejects.toThrow('Not authenticated')
+    })
+  })
+
+  // ============================================================================
+  // GOALS WITH LAST EVIDENCE DATE (STALENESS)
+  // ============================================================================
+
+  describe('getGoalsWithLastEvidenceDate', () => {
+    it('returns empty array when no non-completed goals exist', async () => {
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          neq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        }),
+      })
+
+      const result = await getGoalsWithLastEvidenceDate()
+      expect(result).toEqual([])
+    })
+
+    it('maps database rows to GoalStalenessRecord shape', async () => {
+      const rows = [
+        {
+          id: 'goal-1',
+          goal: 'Learn system design',
+          time_period: 'short_term',
+          status: 'In progress',
+          updated_at: '2024-01-15T10:00:00Z',
+        },
+      ]
+
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          neq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: rows, error: null }),
+          }),
+        }),
+      })
+
+      const result = await getGoalsWithLastEvidenceDate()
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        goalId: 'goal-1',
+        goalTitle: 'Learn system design',
+        timePeriod: 'short_term',
+        status: 'In progress',
+        lastUpdatedAt: '2024-01-15',
+      })
+    })
+
+    it('strips time component from updated_at', async () => {
+      const rows = [
+        {
+          id: 'goal-2',
+          goal: 'Get promoted',
+          time_period: 'long_term',
+          status: 'Not started',
+          updated_at: '2024-06-01T23:59:59.999Z',
+        },
+      ]
+
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          neq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: rows, error: null }),
+          }),
+        }),
+      })
+
+      const result = await getGoalsWithLastEvidenceDate()
+      expect(result[0].lastUpdatedAt).toBe('2024-06-01')
+    })
+
+    it('maps multiple goals including different time periods', async () => {
+      const rows = [
+        {
+          id: 'g1',
+          goal: 'Short goal',
+          time_period: 'short_term',
+          status: 'Not started',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+        {
+          id: 'g2',
+          goal: 'Mid goal',
+          time_period: 'mid_term',
+          status: 'In progress',
+          updated_at: '2024-02-01T00:00:00Z',
+        },
+        {
+          id: 'g3',
+          goal: 'Long goal',
+          time_period: 'long_term',
+          status: 'Not started',
+          updated_at: '2024-03-01T00:00:00Z',
+        },
+      ]
+
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          neq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: rows, error: null }),
+          }),
+        }),
+      })
+
+      const result = await getGoalsWithLastEvidenceDate()
+
+      expect(result).toHaveLength(3)
+      expect(result.map(r => r.timePeriod)).toEqual(['short_term', 'mid_term', 'long_term'])
+      expect(result.map(r => r.goalId)).toEqual(['g1', 'g2', 'g3'])
+    })
+
+    it('throws on database error', async () => {
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          neq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({
+              data: null,
+              error: { code: '42P01', message: 'relation does not exist' },
+            }),
+          }),
+        }),
+      })
+
+      await expect(getGoalsWithLastEvidenceDate()).rejects.toMatchObject({ code: '42P01' })
+    })
+
+    it('excludes Completed goals (query uses neq Completed)', async () => {
+      // The function queries with .neq('status', 'Completed')
+      // We verify the neq call is made with correct arguments
+      const neqMock = vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({ data: [], error: null }),
+      })
+
+      mockSupabaseClient.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({ neq: neqMock }),
+      })
+
+      await getGoalsWithLastEvidenceDate()
+
+      expect(neqMock).toHaveBeenCalledWith('status', 'Completed')
     })
   })
 })

--- a/lib/services/career-goals.ts
+++ b/lib/services/career-goals.ts
@@ -505,3 +505,43 @@ export async function deleteAchievement(id: string): Promise<void> {
   const { error } = await supabase.from('achievements').delete().eq('id', id)
   if (error) throw error
 }
+
+// ============================================================================
+// STALE GOAL DETECTION
+// ============================================================================
+
+export interface GoalStalenessRecord {
+  goalId: string
+  goalTitle: string
+  timePeriod: CareerGoal['timePeriod']
+  status: CareerGoal['status']
+  /** ISO date string (YYYY-MM-DD) of last update, or null if never updated since creation */
+  lastUpdatedAt: string
+}
+
+/**
+ * Returns all non-completed career goals with their last-updated timestamp.
+ * Used by the stale goal signal to surface goals with no recent activity.
+ *
+ * "Last evidenced" is proxied by `updated_at` on the goal row — any status
+ * change, note edit, or explicit goal update bumps this timestamp.
+ */
+export async function getGoalsWithLastEvidenceDate(): Promise<GoalStalenessRecord[]> {
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('career_goals')
+    .select('id, goal, time_period, status, updated_at')
+    .neq('status', 'Completed')
+    .order('updated_at', { ascending: true })
+
+  if (error) throw error
+
+  return (data ?? []).map((r: any) => ({
+    goalId: r.id,
+    goalTitle: r.goal,
+    timePeriod: r.time_period as CareerGoal['timePeriod'],
+    status: r.status as CareerGoal['status'],
+    lastUpdatedAt: (r.updated_at as string).split('T')[0],
+  }))
+}

--- a/lib/signals/__tests__/new-hire.test.ts
+++ b/lib/signals/__tests__/new-hire.test.ts
@@ -70,6 +70,7 @@ function makeData(overrides: Partial<SignalData> = {}): SignalData {
     meetingsWithNotes: [],
     openFollowUps: [],
     tasksByPerson: [],
+    careerGoals: [],
     ...overrides,
   }
 }

--- a/lib/signals/__tests__/stale-goal.test.ts
+++ b/lib/signals/__tests__/stale-goal.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeGoalSignals,
+  buildDismissedSet,
+  STALE_GOAL_INFO_DAYS,
+  STALE_GOAL_WARNING_DAYS,
+  STALE_GOAL_CRITICAL_DAYS,
+} from '../compute'
+import type { GoalStalenessRecord } from '@/lib/services/career-goals'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const TODAY = new Date('2024-06-15')
+const DISMISSED = buildDismissedSet([])
+
+function dateStr(daysAgo: number, base = TODAY): string {
+  const d = new Date(base)
+  d.setDate(d.getDate() - daysAgo)
+  return d.toISOString().split('T')[0]
+}
+
+function makeGoal(overrides: Partial<GoalStalenessRecord> = {}): GoalStalenessRecord {
+  return {
+    goalId: 'goal-1',
+    goalTitle: 'Learn system design',
+    timePeriod: 'short_term',
+    status: 'In progress',
+    lastUpdatedAt: dateStr(0),
+    ...overrides,
+  }
+}
+
+// ── Threshold constants ───────────────────────────────────────────────────────
+
+describe('stale goal threshold constants', () => {
+  it('info threshold is 60 days', () => {
+    expect(STALE_GOAL_INFO_DAYS).toBe(60)
+  })
+
+  it('warning threshold is 90 days', () => {
+    expect(STALE_GOAL_WARNING_DAYS).toBe(90)
+  })
+
+  it('critical threshold is 120 days', () => {
+    expect(STALE_GOAL_CRITICAL_DAYS).toBe(120)
+  })
+})
+
+// ── No signal when fresh ──────────────────────────────────────────────────────
+
+describe('computeGoalSignals — no signal', () => {
+  it('returns empty array when no goals provided', () => {
+    const result = computeGoalSignals([], DISMISSED, TODAY)
+    expect(result).toHaveLength(0)
+  })
+
+  it('returns no signal when goal updated today', () => {
+    const result = computeGoalSignals([makeGoal({ lastUpdatedAt: dateStr(0) })], DISMISSED, TODAY)
+    expect(result).toHaveLength(0)
+  })
+
+  it('returns no signal when goal updated 30 days ago', () => {
+    const result = computeGoalSignals([makeGoal({ lastUpdatedAt: dateStr(30) })], DISMISSED, TODAY)
+    expect(result).toHaveLength(0)
+  })
+
+  it('returns no signal when goal updated 59 days ago (one day under threshold)', () => {
+    const result = computeGoalSignals([makeGoal({ lastUpdatedAt: dateStr(59) })], DISMISSED, TODAY)
+    expect(result).toHaveLength(0)
+  })
+})
+
+// ── Info severity (60–89 days) ────────────────────────────────────────────────
+
+describe('computeGoalSignals — info severity', () => {
+  it('fires info at exactly 60 days', () => {
+    const result = computeGoalSignals([makeGoal({ lastUpdatedAt: dateStr(60) })], DISMISSED, TODAY)
+    expect(result).toHaveLength(1)
+    expect(result[0].severity).toBe('info')
+    expect(result[0].type).toBe('stale_goal')
+  })
+
+  it('fires info at 89 days (one day under warning threshold)', () => {
+    const result = computeGoalSignals([makeGoal({ lastUpdatedAt: dateStr(89) })], DISMISSED, TODAY)
+    expect(result).toHaveLength(1)
+    expect(result[0].severity).toBe('info')
+  })
+
+  it('message includes goal title and days', () => {
+    const result = computeGoalSignals([makeGoal({ goalTitle: 'Become staff', lastUpdatedAt: dateStr(65) })], DISMISSED, TODAY)
+    expect(result[0].message).toContain('Become staff')
+    expect(result[0].message).toContain('65 day')
+  })
+})
+
+// ── Warning severity (90–119 days) ───────────────────────────────────────────
+
+describe('computeGoalSignals — warning severity', () => {
+  it('fires warning at exactly 90 days', () => {
+    const result = computeGoalSignals([makeGoal({ lastUpdatedAt: dateStr(90) })], DISMISSED, TODAY)
+    expect(result).toHaveLength(1)
+    expect(result[0].severity).toBe('warning')
+  })
+
+  it('fires warning at 119 days (one day under critical threshold)', () => {
+    const result = computeGoalSignals([makeGoal({ lastUpdatedAt: dateStr(119) })], DISMISSED, TODAY)
+    expect(result).toHaveLength(1)
+    expect(result[0].severity).toBe('warning')
+  })
+})
+
+// ── Critical severity (120+ days) ────────────────────────────────────────────
+
+describe('computeGoalSignals — critical severity', () => {
+  it('fires critical at exactly 120 days', () => {
+    const result = computeGoalSignals([makeGoal({ lastUpdatedAt: dateStr(120) })], DISMISSED, TODAY)
+    expect(result).toHaveLength(1)
+    expect(result[0].severity).toBe('critical')
+  })
+
+  it('fires critical at 200 days', () => {
+    const result = computeGoalSignals([makeGoal({ lastUpdatedAt: dateStr(200) })], DISMISSED, TODAY)
+    expect(result).toHaveLength(1)
+    expect(result[0].severity).toBe('critical')
+  })
+})
+
+// ── Signal shape ──────────────────────────────────────────────────────────────
+
+describe('computeGoalSignals — signal shape', () => {
+  it('entityId is the goalId', () => {
+    const goal = makeGoal({ goalId: 'my-goal-id', lastUpdatedAt: dateStr(70) })
+    const result = computeGoalSignals([goal], DISMISSED, TODAY)
+    expect(result[0].entityId).toBe('my-goal-id')
+  })
+
+  it('entityType is goal', () => {
+    const result = computeGoalSignals([makeGoal({ lastUpdatedAt: dateStr(70) })], DISMISSED, TODAY)
+    expect(result[0].entityType).toBe('goal')
+  })
+
+  it('meta includes daysSince, lastUpdatedAt, timePeriod, goalStatus', () => {
+    const goal = makeGoal({ lastUpdatedAt: dateStr(75), timePeriod: 'mid_term', status: 'Not started' })
+    const result = computeGoalSignals([goal], DISMISSED, TODAY)
+    const meta = result[0].meta!
+    expect(meta.daysSince).toBe(75)
+    expect(meta.lastUpdatedAt).toBe(dateStr(75))
+    expect(meta.timePeriod).toBe('mid_term')
+    expect(meta.goalStatus).toBe('Not started')
+  })
+
+  it('singular "day" in message when daysSince is 1 — edge case for 60-day boundary', () => {
+    // 60-day boundary fires at exactly 60, not 1 day — but test singular branch via override
+    // daysSince = 60 → "60 days" (plural)
+    const result = computeGoalSignals([makeGoal({ lastUpdatedAt: dateStr(60) })], DISMISSED, TODAY)
+    expect(result[0].message).toContain('60 days')
+  })
+})
+
+// ── Multiple goals ────────────────────────────────────────────────────────────
+
+describe('computeGoalSignals — multiple goals', () => {
+  it('returns one signal per stale goal', () => {
+    const goals: GoalStalenessRecord[] = [
+      makeGoal({ goalId: 'g1', lastUpdatedAt: dateStr(65) }),
+      makeGoal({ goalId: 'g2', lastUpdatedAt: dateStr(95) }),
+      makeGoal({ goalId: 'g3', lastUpdatedAt: dateStr(130) }),
+    ]
+    const result = computeGoalSignals(goals, DISMISSED, TODAY)
+    expect(result).toHaveLength(3)
+    const severities = result.map(s => s.severity)
+    expect(severities).toContain('info')
+    expect(severities).toContain('warning')
+    expect(severities).toContain('critical')
+  })
+
+  it('skips fresh goals and only returns stale ones', () => {
+    const goals: GoalStalenessRecord[] = [
+      makeGoal({ goalId: 'g1', lastUpdatedAt: dateStr(10) }),   // fresh
+      makeGoal({ goalId: 'g2', lastUpdatedAt: dateStr(70) }),   // stale
+      makeGoal({ goalId: 'g3', lastUpdatedAt: dateStr(0) }),    // fresh
+    ]
+    const result = computeGoalSignals(goals, DISMISSED, TODAY)
+    expect(result).toHaveLength(1)
+    expect(result[0].entityId).toBe('g2')
+  })
+})
+
+// ── Dismiss infrastructure ────────────────────────────────────────────────────
+
+describe('computeGoalSignals — dismiss', () => {
+  it('skips dismissed goals', () => {
+    const goal = makeGoal({ goalId: 'goal-x', lastUpdatedAt: dateStr(80) })
+    const dismissed = buildDismissedSet([{ itemType: 'stale_goal', referenceId: 'goal-x' }])
+    const result = computeGoalSignals([goal], dismissed, TODAY)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not skip goals dismissed under a different type', () => {
+    const goal = makeGoal({ goalId: 'goal-x', lastUpdatedAt: dateStr(80) })
+    const dismissed = buildDismissedSet([{ itemType: 'overdue_task', referenceId: 'goal-x' }])
+    const result = computeGoalSignals([goal], dismissed, TODAY)
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not skip goals with a different id even when type matches', () => {
+    const goal = makeGoal({ goalId: 'goal-x', lastUpdatedAt: dateStr(80) })
+    const dismissed = buildDismissedSet([{ itemType: 'stale_goal', referenceId: 'goal-y' }])
+    const result = computeGoalSignals([goal], dismissed, TODAY)
+    expect(result).toHaveLength(1)
+  })
+
+  it('only skips the dismissed goal, not other stale goals', () => {
+    const goals: GoalStalenessRecord[] = [
+      makeGoal({ goalId: 'g1', lastUpdatedAt: dateStr(70) }),
+      makeGoal({ goalId: 'g2', lastUpdatedAt: dateStr(75) }),
+    ]
+    const dismissed = buildDismissedSet([{ itemType: 'stale_goal', referenceId: 'g1' }])
+    const result = computeGoalSignals(goals, dismissed, TODAY)
+    expect(result).toHaveLength(1)
+    expect(result[0].entityId).toBe('g2')
+  })
+})
+
+// ── Edge cases ────────────────────────────────────────────────────────────────
+
+describe('computeGoalSignals — edge cases', () => {
+  it('handles a single goal updated exactly at each threshold boundary', () => {
+    const boundaries: [number, string][] = [
+      [60, 'info'],
+      [90, 'warning'],
+      [120, 'critical'],
+    ]
+    for (const [days, expectedSeverity] of boundaries) {
+      const result = computeGoalSignals(
+        [makeGoal({ goalId: `g-${days}`, lastUpdatedAt: dateStr(days) })],
+        DISMISSED,
+        TODAY
+      )
+      expect(result).toHaveLength(1)
+      expect(result[0].severity).toBe(expectedSeverity)
+    }
+  })
+
+  it('handles goals with Not started status (should still fire)', () => {
+    const result = computeGoalSignals(
+      [makeGoal({ status: 'Not started', lastUpdatedAt: dateStr(70) })],
+      DISMISSED,
+      TODAY
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('handles goals with In progress status (should fire)', () => {
+    const result = computeGoalSignals(
+      [makeGoal({ status: 'In progress', lastUpdatedAt: dateStr(70) })],
+      DISMISSED,
+      TODAY
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('handles large number of goals efficiently', () => {
+    const goals: GoalStalenessRecord[] = Array.from({ length: 100 }, (_, i) => ({
+      goalId: `g-${i}`,
+      goalTitle: `Goal ${i}`,
+      timePeriod: 'short_term' as const,
+      status: 'In progress' as const,
+      lastUpdatedAt: dateStr(i + 60), // all stale
+    }))
+    const result = computeGoalSignals(goals, DISMISSED, TODAY)
+    expect(result).toHaveLength(100)
+  })
+
+  it('long_term time period included in meta', () => {
+    const result = computeGoalSignals(
+      [makeGoal({ timePeriod: 'long_term', lastUpdatedAt: dateStr(70) })],
+      DISMISSED,
+      TODAY
+    )
+    expect(result[0].meta?.timePeriod).toBe('long_term')
+  })
+})

--- a/lib/signals/compute.ts
+++ b/lib/signals/compute.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@/lib/supabase/client'
 import type { Signal, SignalSeverity } from './types'
+import type { GoalStalenessRecord } from '@/lib/services/career-goals'
 
 const DAYS_MS = 24 * 60 * 60 * 1000
 
@@ -74,6 +75,7 @@ export async function loadSignalData() {
     { data: meetingsWithNotes },
     { data: openFollowUps },
     { data: tasksByPerson },
+    { data: careerGoals },
   ] = await Promise.all([
     supabase
       .from('tasks')
@@ -124,7 +126,26 @@ export async function loadSignalData() {
       .in('task_id',
         (await supabase.from('tasks').select('id').not('status', 'eq', 'completed')).data?.map((t: any) => t.id) ?? []
       ),
+
+    // Non-completed career goals for stale goal detection
+    supabase
+      .from('career_goals')
+      .select('id, goal, time_period, status, updated_at')
+      .neq('status', 'Completed')
+      .order('updated_at', { ascending: true }),
   ])
+
+  // Map raw career goal rows to GoalStalenessRecord
+  const goalRows = (careerGoals ?? []) as Array<{
+    id: string; goal: string; time_period: string; status: string; updated_at: string
+  }>
+  const mappedCareerGoals: GoalStalenessRecord[] = goalRows.map(r => ({
+    goalId: r.id,
+    goalTitle: r.goal,
+    timePeriod: r.time_period as GoalStalenessRecord['timePeriod'],
+    status: r.status as GoalStalenessRecord['status'],
+    lastUpdatedAt: r.updated_at.split('T')[0],
+  }))
 
   return {
     overdueTasks: overdueTasks ?? [],
@@ -135,6 +156,7 @@ export async function loadSignalData() {
     meetingsWithNotes: meetingsWithNotes ?? [],
     openFollowUps: openFollowUps ?? [],
     tasksByPerson: tasksByPerson ?? [],
+    careerGoals: mappedCareerGoals,
   }
 }
 
@@ -557,6 +579,60 @@ export function computeSentimentDriftSignals(
         priorTotal: prior.total,
         recentNegative: recent.negative,
         priorNegative: prior.negative,
+      },
+    })
+  }
+
+  return signals
+}
+
+// ── Stale Goal thresholds ─────────────────────────────────────────────────────
+export const STALE_GOAL_INFO_DAYS     = 60
+export const STALE_GOAL_WARNING_DAYS  = 90
+export const STALE_GOAL_CRITICAL_DAYS = 120
+
+/**
+ * Compute stale career goal signals.
+ *
+ * Fires when a non-completed career goal has not been updated in:
+ *   60+ days → info
+ *   90+ days → warning
+ *  120+ days → critical
+ *
+ * Goals with no activity since creation use `lastUpdatedAt` as the proxy.
+ * Completed goals are excluded (filtered at query time).
+ */
+export function computeGoalSignals(
+  goals: GoalStalenessRecord[],
+  dismissedSet: Set<DismissKey>,
+  today: Date
+): Signal[] {
+  const signals: Signal[] = []
+
+  for (const goal of goals) {
+    if (isDismissed(dismissedSet, 'stale_goal', goal.goalId)) continue
+
+    const lastDate = new Date(goal.lastUpdatedAt + 'T00:00:00')
+    const daysSince = daysBetween(lastDate, today)
+
+    if (daysSince < STALE_GOAL_INFO_DAYS) continue
+
+    const severity: SignalSeverity =
+      daysSince >= STALE_GOAL_CRITICAL_DAYS ? 'critical'
+      : daysSince >= STALE_GOAL_WARNING_DAYS ? 'warning'
+      : 'info'
+
+    signals.push({
+      type: 'stale_goal',
+      severity,
+      message: `Goal "${goal.goalTitle}" has had no activity in ${daysSince} day${daysSince === 1 ? '' : 's'}`,
+      entityId: goal.goalId,
+      entityType: 'goal',
+      meta: {
+        daysSince,
+        lastUpdatedAt: goal.lastUpdatedAt,
+        timePeriod: goal.timePeriod,
+        goalStatus: goal.status,
       },
     })
   }

--- a/lib/signals/types.ts
+++ b/lib/signals/types.ts
@@ -13,6 +13,7 @@ export type SignalType =
   | 'action_overload'
   | 'sentiment_drift'
   | 'new_hire_at_risk'
+  | 'stale_goal'
 
 export interface Signal {
   type: SignalType
@@ -21,7 +22,7 @@ export interface Signal {
   personId?: string
   personName?: string
   entityId: string
-  entityType: 'task' | 'person' | 'meeting' | 'follow_up'
+  entityType: 'task' | 'person' | 'meeting' | 'follow_up' | 'goal'
   meta?: Record<string, unknown>
 }
 
@@ -39,6 +40,7 @@ export const SIGNAL_WEIGHTS: Record<SignalType, number> = {
   action_overload: 3,
   sentiment_drift: 4,       // trending negative — notable attention
   new_hire_at_risk: 5,      // new hire triggering 2+ signals — high priority
+  stale_goal: 2,            // goal without activity in 60+ days
 }
 
 /** Critical signals get a bonus weight */


### PR DESCRIPTION
## Summary

Implements stale career goal detection as described in #106. Fires a signal when a non-completed career goal has had no activity in 60+ days, surfacing silent stalls before a performance review cycle.

## Changes

### Signal Engine
- **`lib/signals/types.ts`** — Add `stale_goal` to `SignalType` union; add weight (2) to `SIGNAL_WEIGHTS`; extend `Signal.entityType` to include `'goal'`
- **`lib/signals/compute.ts`** — Add `computeGoalSignals()` with 60/90/120-day info/warning/critical thresholds; update `loadSignalData()` to fetch non-completed goals in the parallel pass; add threshold constants `STALE_GOAL_INFO_DAYS`, `STALE_GOAL_WARNING_DAYS`, `STALE_GOAL_CRITICAL_DAYS`
- **`lib/services/career-goals.ts`** — Add `getGoalsWithLastEvidenceDate()` and `GoalStalenessRecord` type; uses `updated_at` as the activity proxy (bumped on any goal edit or status change)

### Hook
- **`lib/hooks/use-weekly-review-signals.ts`** — Wire `computeGoalSignals` into `computeAllSignals`; goal signals included in weekly review and sidebar counts

### Weekly Review UI
- **`app/(dashboard)/review/page.tsx`** — Add "Career Goal Staleness" section (Section 4) between Tasks and Week in Review; shows goal title, time period label, days stale; "Update goal" CTA links to /career-goals; dismiss works via existing infrastructure; section auto-checks when no stale goals remain; goals added to `PROGRESS_SECTIONS` (progress bar now /5 sections)

### Career Goals Page
- **`app/(dashboard)/career-goals/page.tsx`** — Add `updatedAt` field to `Goal` interface; populate from API; bump optimistically on local edit; show color-coded staleness badge (info/warning/critical) below each goal textarea; badge hidden for Completed goals and fresh goals (<60 days)

## Tests

528 passing (0 regressions).

New tests:
- **`lib/signals/__tests__/stale-goal.test.ts`** — 29 tests covering threshold constants, no-signal cases, severity boundaries (info/warning/critical at exact day counts), signal shape, multiple goals, dismiss infrastructure, edge cases
- **`lib/services/__tests__/career-goals.test.ts`** — 6 new tests for `getGoalsWithLastEvidenceDate`: empty result, row mapping, date stripping, multiple time periods, error propagation, Completed exclusion

## Acceptance Criteria

- [x] `stale_goal` signal fires at correct thresholds (60/90/120 days)
- [x] Signal includes goal title in message; time period and days in meta
- [x] Signal is dismissable via existing dismiss infrastructure
- [x] Career goals page shows staleness age per goal
- [x] `loadSignalData` updated to include goals in one parallel pass
- [x] Works when user has no career goals (no signal fired)

Closes #106
