### PR TITLE
feat: AI-assisted follow-up message drafts after 1:1s

### DIFF
--- a/app/(dashboard)/meetings/page.tsx
+++ b/app/(dashboard)/meetings/page.tsx
@@ -8,6 +8,7 @@ import { ChevronRight, ChevronDown, ChevronsRight, ChevronsDown, BookOpen, ListC
 import { LogEvidenceModal } from "@/components/evidence/log-evidence-modal"
 import { FollowUpForm } from "@/components/follow-ups/follow-up-form"
 import { MeetingFormDialog } from "@/components/meeting-form-dialog"
+import { FollowUpDraftModal } from "@/components/follow-up-draft-modal"
 import { AIButton } from "@/components/ui/ai-button"
 import { useAIConfig } from "@/lib/hooks/use-ai-config"
 import { callAI, handleAIError } from "@/lib/services/ai"
@@ -72,6 +73,9 @@ export default function MeetingsPage() {
   const [logEvidenceOpen, setLogEvidenceOpen] = useState(false)
   const [trackFollowUpOpen, setTrackFollowUpOpen] = useState(false)
   const [extractingActions, setExtractingActions] = useState(false)
+  const [followUpDraftOpen, setFollowUpDraftOpen] = useState(false)
+  const [followUpDraftMeeting, setFollowUpDraftMeeting] = useState<Meeting | null>(null)
+  const [showFollowUpBanner, setShowFollowUpBanner] = useState(false)
   const aiConfig = useAIConfig()
 
   useEffect(() => {
@@ -236,6 +240,12 @@ export default function MeetingsPage() {
 
       setMeetings([uiMeeting, ...meetings])
       setSelectedMeeting(uiMeeting)
+
+      // Offer AI follow-up draft if AI is configured and meeting has notes or action items
+      if (aiConfig.configured && (uiMeeting.notes || uiMeeting.actionItems)) {
+        setFollowUpDraftMeeting(uiMeeting)
+        setShowFollowUpBanner(true)
+      }
 
       const actionItemTexts = parseActionItems(newMeeting.actionItems || "")
       if (actionItemTexts.length > 0) {
@@ -664,6 +674,34 @@ export default function MeetingsPage() {
         <div style={{ flex: 1, overflowY: "auto", padding: "22px 24px" }}>
           {selectedMeeting ? (
             <div>
+              {/* Follow-up draft banner — shown after a new meeting is saved with AI configured */}
+              {showFollowUpBanner && followUpDraftMeeting?.id === selectedMeeting.id && (
+                <div style={{
+                  display: "flex", alignItems: "center", justifyContent: "space-between",
+                  gap: "12px", padding: "10px 14px", marginBottom: "16px",
+                  borderRadius: "6px", border: "1px solid var(--border-2)",
+                  background: "var(--surf-2)",
+                }}>
+                  <p style={{ fontSize: "var(--text-label)", color: "var(--text-2)", margin: 0 }}>
+                    Meeting saved. Draft a follow-up message?
+                  </p>
+                  <div style={{ display: "flex", gap: "6px", flexShrink: 0 }}>
+                    <button
+                      onClick={() => setFollowUpDraftOpen(true)}
+                      style={{ padding: "4px 12px", borderRadius: "4px", fontSize: "var(--text-label)", fontFamily: "var(--font-sans)", cursor: "pointer", background: "var(--surf-3)", color: "var(--text-1)", border: "1px solid var(--border-3)", fontWeight: 600 }}
+                    >
+                      Draft message
+                    </button>
+                    <button
+                      onClick={() => setShowFollowUpBanner(false)}
+                      style={{ padding: "4px 10px", borderRadius: "4px", fontSize: "var(--text-label)", fontFamily: "var(--font-sans)", cursor: "pointer", background: "transparent", color: "var(--text-3)", border: "1px solid var(--border-2)" }}
+                    >
+                      Dismiss
+                    </button>
+                  </div>
+                </div>
+              )}
+
               {/* Title */}
               <h1 style={{ marginBottom: "4px" }}>
                 {selectedMeeting.title}
@@ -877,6 +915,24 @@ export default function MeetingsPage() {
           sourceId={selectedMeeting.id}
           onSaved={() => setTrackFollowUpOpen(false)}
           onCancel={() => setTrackFollowUpOpen(false)}
+        />
+      )}
+
+      {followUpDraftMeeting && (
+        <FollowUpDraftModal
+          open={followUpDraftOpen}
+          onOpenChange={(open) => {
+            setFollowUpDraftOpen(open)
+            if (!open) setShowFollowUpBanner(false)
+          }}
+          meetingArgs={{
+            personName: followUpDraftMeeting.personName ?? followUpDraftMeeting.attendees[0] ?? '',
+            meetingTitle: followUpDraftMeeting.title,
+            meetingDate: followUpDraftMeeting.date,
+            notes: followUpDraftMeeting.notes ?? null,
+            actionItems: followUpDraftMeeting.actionItems ?? null,
+            followUps: [],
+          }}
         />
       )}
     </div>

--- a/components/__tests__/follow-up-draft-modal.test.tsx
+++ b/components/__tests__/follow-up-draft-modal.test.tsx
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '../../test/mocks/supabase'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockCallAI = vi.fn()
+const mockHandleAIError = vi.fn()
+
+vi.mock('@/lib/services/ai', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/services/ai')>()
+  return {
+    ...actual,
+    callAI: (...args: unknown[]) => mockCallAI(...args),
+    handleAIError: (...args: unknown[]) => mockHandleAIError(...args),
+  }
+})
+
+// Navigator clipboard
+const writeText = vi.fn().mockResolvedValue(undefined)
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText },
+  writable: true,
+  configurable: true,
+})
+
+import { FollowUpDraftModal, type FollowUpDraftModalProps } from '../follow-up-draft-modal'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_MEETING_ARGS: FollowUpDraftModalProps['meetingArgs'] = {
+  personName:   'Alice Chen',
+  meetingTitle: '1:1 with Alice',
+  meetingDate:  '2026-05-23',
+  notes:        'Discussed roadmap and promotion.',
+  actionItems:  '- Write spec\n- Review PR',
+  followUps:    [{ title: 'Share salary band info' }],
+}
+
+function renderModal(overrides: Partial<FollowUpDraftModalProps> = {}) {
+  const props: FollowUpDraftModalProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    meetingArgs: DEFAULT_MEETING_ARGS,
+    ...overrides,
+  }
+  return { ...render(<FollowUpDraftModal {...props} />), props }
+}
+
+const MOCK_AI_RESPONSE = {
+  content: 'Hi Alice, thanks for the chat today. I will share the salary band info and look at the spec by Friday.',
+  tokensUsed: { input: 100, output: 50 },
+  model: 'claude-sonnet-4-6',
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('FollowUpDraftModal', () => {
+  beforeEach(() => {
+    mockCallAI.mockReset()
+    mockHandleAIError.mockReset()
+    writeText.mockReset().mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ─── Rendering ─────────────────────────────────────────────────────────────
+
+  it('renders the dialog title', () => {
+    renderModal()
+    expect(screen.getByText('Draft follow-up message')).toBeTruthy()
+  })
+
+  it('renders person name in description when provided', () => {
+    renderModal()
+    expect(screen.getByText(/Alice Chen/)).toBeTruthy()
+  })
+
+  it('renders all three tone options', () => {
+    renderModal()
+    expect(screen.getByText('Formal')).toBeTruthy()
+    expect(screen.getByText('Casual')).toBeTruthy()
+    expect(screen.getByText('Slack')).toBeTruthy()
+  })
+
+  it('shows Generate draft button before any generation', () => {
+    renderModal()
+    expect(screen.getByText('Generate draft')).toBeTruthy()
+  })
+
+  it('does not show Regenerate or Copy buttons before generation', () => {
+    renderModal()
+    expect(screen.queryByText('Regenerate')).toBeNull()
+    expect(screen.queryByText('Copy to clipboard')).toBeNull()
+  })
+
+  it('shows message when meeting has no notes or action items', () => {
+    renderModal({
+      meetingArgs: { ...DEFAULT_MEETING_ARGS, notes: null, actionItems: null },
+    })
+    expect(screen.getByText(/No notes or action items/)).toBeTruthy()
+  })
+
+  // ─── Tone selector ─────────────────────────────────────────────────────────
+
+  it('defaults to casual tone', () => {
+    renderModal()
+    // Description under tone selector should match casual
+    expect(screen.getByText('Warm, conversational')).toBeTruthy()
+  })
+
+  it('switches tone description when another tone is selected', () => {
+    renderModal()
+    fireEvent.click(screen.getByText('Formal'))
+    expect(screen.getByText('Professional, full sentences')).toBeTruthy()
+  })
+
+  it('switches to slack description when slack is selected', () => {
+    renderModal()
+    fireEvent.click(screen.getByText('Slack'))
+    expect(screen.getByText('Short, bullet-point friendly')).toBeTruthy()
+  })
+
+  // ─── Generation ─────────────────────────────────────────────────────────────
+
+  it('calls callAI when Generate draft is clicked', async () => {
+    mockCallAI.mockResolvedValueOnce(MOCK_AI_RESPONSE)
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    await waitFor(() => expect(mockCallAI).toHaveBeenCalledTimes(1))
+  })
+
+  it('shows loading state while generating', async () => {
+    let resolve: (v: typeof MOCK_AI_RESPONSE) => void
+    mockCallAI.mockReturnValueOnce(new Promise((r) => { resolve = r }))
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    expect(screen.getByText(/Drafting message/)).toBeTruthy()
+    resolve!(MOCK_AI_RESPONSE)
+  })
+
+  it('shows draft text after generation', async () => {
+    mockCallAI.mockResolvedValueOnce(MOCK_AI_RESPONSE)
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    await waitFor(() =>
+      expect(screen.getByDisplayValue(/Hi Alice/)).toBeTruthy()
+    )
+  })
+
+  it('shows Regenerate button after first generation', async () => {
+    mockCallAI.mockResolvedValueOnce(MOCK_AI_RESPONSE)
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    await waitFor(() => expect(screen.getByText('Regenerate')).toBeTruthy())
+  })
+
+  it('shows Copy to clipboard button after generation', async () => {
+    mockCallAI.mockResolvedValueOnce(MOCK_AI_RESPONSE)
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    await waitFor(() => expect(screen.getByText('Copy to clipboard')).toBeTruthy())
+  })
+
+  // ─── Regenerate ─────────────────────────────────────────────────────────────
+
+  it('calls callAI again when Regenerate is clicked', async () => {
+    mockCallAI.mockResolvedValue(MOCK_AI_RESPONSE)
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    await waitFor(() => screen.getByText('Regenerate'))
+    fireEvent.click(screen.getByText('Regenerate'))
+    await waitFor(() => expect(mockCallAI).toHaveBeenCalledTimes(2))
+  })
+
+  it('auto-regenerates when tone is changed after first generation', async () => {
+    mockCallAI.mockResolvedValue(MOCK_AI_RESPONSE)
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    await waitFor(() => screen.getByText('Regenerate'))
+    fireEvent.click(screen.getByText('Formal'))
+    await waitFor(() => expect(mockCallAI).toHaveBeenCalledTimes(2))
+  })
+
+  it('does NOT auto-regenerate on tone change before first generation', () => {
+    renderModal()
+    fireEvent.click(screen.getByText('Formal'))
+    expect(mockCallAI).not.toHaveBeenCalled()
+  })
+
+  // ─── Copy to clipboard ──────────────────────────────────────────────────────
+
+  it('copies draft to clipboard when Copy is clicked', async () => {
+    mockCallAI.mockResolvedValueOnce(MOCK_AI_RESPONSE)
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    await waitFor(() => screen.getByText('Copy to clipboard'))
+    fireEvent.click(screen.getByText('Copy to clipboard'))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(MOCK_AI_RESPONSE.content))
+  })
+
+  it('shows Copied confirmation after copy', async () => {
+    mockCallAI.mockResolvedValueOnce(MOCK_AI_RESPONSE)
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    await waitFor(() => screen.getByText('Copy to clipboard'))
+    fireEvent.click(screen.getByText('Copy to clipboard'))
+    await waitFor(() => expect(screen.getByText('Copied')).toBeTruthy())
+  })
+
+  // ─── Error state ─────────────────────────────────────────────────────────────
+
+  it('shows error message when callAI throws', async () => {
+    mockCallAI.mockRejectedValueOnce(new Error('API key invalid'))
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    await waitFor(() => expect(screen.getByText('API key invalid')).toBeTruthy())
+  })
+
+  it('calls handleAIError when callAI throws', async () => {
+    mockCallAI.mockRejectedValueOnce(new Error('Network error'))
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    await waitFor(() => expect(mockHandleAIError).toHaveBeenCalledTimes(1))
+  })
+
+  it('shows Try again button after error', async () => {
+    mockCallAI.mockRejectedValueOnce(new Error('Bad gateway'))
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    await waitFor(() => expect(screen.getByText('Try again')).toBeTruthy())
+  })
+
+  // ─── Draft editable ──────────────────────────────────────────────────────────
+
+  it('allows editing the draft text', async () => {
+    mockCallAI.mockResolvedValueOnce(MOCK_AI_RESPONSE)
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    const textarea = await waitFor(() =>
+      screen.getByDisplayValue(/Hi Alice/)
+    ) as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: 'Custom message' } })
+    expect(textarea.value).toBe('Custom message')
+  })
+
+  // ─── Close / reset ───────────────────────────────────────────────────────────
+
+  it('calls onOpenChange(false) when Close button is clicked', () => {
+    const onOpenChange = vi.fn()
+    renderModal({ onOpenChange })
+    // The dialog has two "Close" elements: the sr-only Radix X button and our explicit Close button.
+    // Get the visible one by role with accessible name.
+    const closeButtons = screen.getAllByText('Close')
+    // Our explicit Close button is the one that is not sr-only
+    const visibleClose = closeButtons.find(
+      (el) => !el.classList.contains('sr-only') && el.tagName !== 'SPAN'
+    )
+    fireEvent.click(visibleClose!)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  // ─── AI prompt wiring ────────────────────────────────────────────────────────
+
+  it('passes FOLLOW_UP_DRAFT_SYSTEM as systemPrompt', async () => {
+    mockCallAI.mockResolvedValueOnce(MOCK_AI_RESPONSE)
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    await waitFor(() => expect(mockCallAI).toHaveBeenCalled())
+    const [request] = mockCallAI.mock.calls[0]
+    expect(request.systemPrompt).toContain('200 words')
+    expect(request.systemPrompt).toContain('formal')
+  })
+
+  it('includes person name in user prompt', async () => {
+    mockCallAI.mockResolvedValueOnce(MOCK_AI_RESPONSE)
+    renderModal()
+    fireEvent.click(screen.getByText('Generate draft'))
+    await waitFor(() => expect(mockCallAI).toHaveBeenCalled())
+    const [request] = mockCallAI.mock.calls[0]
+    expect(request.userPrompt).toContain('Alice Chen')
+  })
+
+  it('includes selected tone in user prompt', async () => {
+    mockCallAI.mockResolvedValueOnce(MOCK_AI_RESPONSE)
+    renderModal()
+    fireEvent.click(screen.getByText('Formal'))
+    fireEvent.click(screen.getByText('Generate draft'))
+    await waitFor(() => expect(mockCallAI).toHaveBeenCalled())
+    const [request] = mockCallAI.mock.calls[0]
+    expect(request.userPrompt).toContain('formal')
+  })
+})

--- a/components/follow-up-draft-modal.tsx
+++ b/components/follow-up-draft-modal.tsx
@@ -145,18 +145,7 @@ export function FollowUpDraftModal({ open, onOpenChange, meetingArgs }: FollowUp
           </div>
 
           {/* Draft area */}
-          {!hasGenerated && !loading ? (
-            <div className="flex flex-col items-center justify-center gap-3 py-8 rounded-md border border-dashed border-border">
-              <p className="text-sm text-muted-foreground text-center">
-                {meetingArgs.notes || meetingArgs.actionItems
-                  ? "Click generate to draft a follow-up based on your meeting."
-                  : "No notes or action items — the draft will be a general meeting summary."}
-              </p>
-              <Button type="button" onClick={handleGenerate} disabled={loading}>
-                Generate draft
-              </Button>
-            </div>
-          ) : loading ? (
+          {loading ? (
             <div className="flex flex-col items-center justify-center gap-2 py-10">
               <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
               <p className="text-sm text-muted-foreground">Drafting message…</p>
@@ -166,6 +155,17 @@ export function FollowUpDraftModal({ open, onOpenChange, meetingArgs }: FollowUp
               <p className="text-sm text-destructive">{error}</p>
               <Button type="button" variant="outline" size="sm" onClick={handleGenerate}>
                 Try again
+              </Button>
+            </div>
+          ) : !hasGenerated ? (
+            <div className="flex flex-col items-center justify-center gap-3 py-8 rounded-md border border-dashed border-border">
+              <p className="text-sm text-muted-foreground text-center">
+                {meetingArgs.notes || meetingArgs.actionItems
+                  ? "Click generate to draft a follow-up based on your meeting."
+                  : "No notes or action items — the draft will be a general meeting summary."}
+              </p>
+              <Button type="button" onClick={handleGenerate} disabled={loading}>
+                Generate draft
               </Button>
             </div>
           ) : (

--- a/components/follow-up-draft-modal.tsx
+++ b/components/follow-up-draft-modal.tsx
@@ -1,0 +1,227 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import { Copy, Check, RefreshCw, Loader2 } from "lucide-react"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { callAI, handleAIError } from "@/lib/services/ai"
+import {
+  FOLLOW_UP_DRAFT_SYSTEM,
+  buildFollowUpDraftPrompt,
+  type FollowUpDraftTone,
+  type FollowUpDraftArgs,
+} from "@/lib/ai/prompts"
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface FollowUpDraftModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  meetingArgs: Omit<FollowUpDraftArgs, "tone">
+}
+
+// ─── Tone options ─────────────────────────────────────────────────────────────
+
+const TONE_OPTIONS: Array<{ value: FollowUpDraftTone; label: string; description: string }> = [
+  { value: "formal",  label: "Formal",  description: "Professional, full sentences" },
+  { value: "casual",  label: "Casual",  description: "Warm, conversational" },
+  { value: "slack",   label: "Slack",   description: "Short, bullet-point friendly" },
+]
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function FollowUpDraftModal({ open, onOpenChange, meetingArgs }: FollowUpDraftModalProps) {
+  const [tone, setTone]         = useState<FollowUpDraftTone>("casual")
+  const [draft, setDraft]       = useState("")
+  const [loading, setLoading]   = useState(false)
+  const [copied, setCopied]     = useState(false)
+  const [hasGenerated, setHasGenerated] = useState(false)
+  const [error, setError]       = useState<string | null>(null)
+
+  const generate = useCallback(async (selectedTone: FollowUpDraftTone) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await callAI({
+        systemPrompt: FOLLOW_UP_DRAFT_SYSTEM,
+        userPrompt: buildFollowUpDraftPrompt({ ...meetingArgs, tone: selectedTone }),
+        maxTokens: 400,
+        temperature: 0.7,
+      })
+      setDraft(result.content.trim())
+      setHasGenerated(true)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to generate draft"
+      setError(msg)
+      handleAIError(err)
+    } finally {
+      setLoading(false)
+    }
+  }, [meetingArgs])
+
+  const handleToneChange = (newTone: FollowUpDraftTone) => {
+    setTone(newTone)
+    if (hasGenerated) {
+      // Auto-regenerate when tone changes after first generation
+      generate(newTone)
+    }
+  }
+
+  const handleGenerate = () => generate(tone)
+
+  const handleCopy = async () => {
+    if (!draft) return
+    try {
+      await navigator.clipboard.writeText(draft)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Fallback for environments without clipboard API
+      const el = document.createElement("textarea")
+      el.value = draft
+      document.body.appendChild(el)
+      el.select()
+      document.execCommand("copy")
+      document.body.removeChild(el)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      // Reset state when closing so next open is fresh
+      setDraft("")
+      setHasGenerated(false)
+      setError(null)
+      setCopied(false)
+    }
+    onOpenChange(nextOpen)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[580px]">
+        <DialogHeader>
+          <DialogTitle>Draft follow-up message</DialogTitle>
+          <DialogDescription>
+            {meetingArgs.personName
+              ? `Draft a follow-up for ${meetingArgs.personName} based on your meeting notes and action items.`
+              : "Draft a follow-up message based on your meeting notes and action items."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          {/* Tone selector */}
+          <div className="flex flex-col gap-2">
+            <p className="text-sm font-medium">Tone</p>
+            <div className="flex gap-2">
+              {TONE_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => handleToneChange(opt.value)}
+                  title={opt.description}
+                  style={{
+                    padding: "4px 14px",
+                    borderRadius: "4px",
+                    fontSize: "var(--text-label)",
+                    fontFamily: "var(--font-sans)",
+                    cursor: "pointer",
+                    background: tone === opt.value ? "var(--surf-3)" : "var(--surf-2)",
+                    color: tone === opt.value ? "var(--text-1)" : "var(--text-2)",
+                    border: `1px solid ${tone === opt.value ? "var(--border-3)" : "var(--border-2)"}`,
+                    transition: "background 0.1s",
+                  }}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {TONE_OPTIONS.find((o) => o.value === tone)?.description}
+            </p>
+          </div>
+
+          {/* Draft area */}
+          {!hasGenerated && !loading ? (
+            <div className="flex flex-col items-center justify-center gap-3 py-8 rounded-md border border-dashed border-border">
+              <p className="text-sm text-muted-foreground text-center">
+                {meetingArgs.notes || meetingArgs.actionItems
+                  ? "Click generate to draft a follow-up based on your meeting."
+                  : "No notes or action items — the draft will be a general meeting summary."}
+              </p>
+              <Button type="button" onClick={handleGenerate} disabled={loading}>
+                Generate draft
+              </Button>
+            </div>
+          ) : loading ? (
+            <div className="flex flex-col items-center justify-center gap-2 py-10">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">Drafting message…</p>
+            </div>
+          ) : error ? (
+            <div className="flex flex-col gap-2">
+              <p className="text-sm text-destructive">{error}</p>
+              <Button type="button" variant="outline" size="sm" onClick={handleGenerate}>
+                Try again
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-medium">Draft</p>
+                <p className="text-xs text-muted-foreground">Edit before sending</p>
+              </div>
+              <Textarea
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                rows={8}
+                className="resize-none text-sm font-mono"
+              />
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="flex-row justify-between sm:justify-between">
+          <div className="flex gap-2">
+            {hasGenerated && !loading && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleGenerate}
+                disabled={loading}
+                className="gap-1.5"
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+                Regenerate
+              </Button>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+              Close
+            </Button>
+            {hasGenerated && !loading && draft && (
+              <Button type="button" onClick={handleCopy} className="gap-1.5">
+                {copied ? (
+                  <>
+                    <Check className="h-3.5 w-3.5" />
+                    Copied
+                  </>
+                ) : (
+                  <>
+                    <Copy className="h-3.5 w-3.5" />
+                    Copy to clipboard
+                  </>
+                )}
+              </Button>
+            )}
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -160,6 +160,70 @@ ${assessmentText}
 ${evidenceText}`, 6000)
 }
 
+// ─── Follow-up Draft ─────────────────────────────────────────────────────────
+
+export type FollowUpDraftTone = 'formal' | 'casual' | 'slack'
+
+export const FOLLOW_UP_DRAFT_SYSTEM = `You are an engineering manager writing a follow-up message to a direct report after a 1:1 or meeting.
+
+Write a concise, professional follow-up message the manager can send directly. The message should:
+- Open with a brief acknowledgement of the meeting
+- Reference specific action items and commitments made (by name, not vaguely)
+- List next steps clearly so the recipient knows what to expect
+- Close naturally
+
+Rules:
+- Keep under 200 words
+- Do not fabricate items not mentioned in the input
+- If there are no action items or follow-ups, write a general summary of what was discussed
+- Do not use em-dashes or corporate filler phrases ("as per our discussion", "going forward")
+- Output plain text only — no markdown headers
+
+Tone variants:
+- formal: professional, third-person-neutral, full sentences
+- casual: warm, first-person, conversational — as if sent to someone you know well
+- slack: very short, bullet-point friendly, Slack-ready (you may use emoji sparingly)`
+
+export interface FollowUpDraftArgs {
+  personName: string
+  meetingTitle: string
+  meetingDate: string
+  notes: string | null | undefined
+  actionItems: string | null | undefined
+  followUps: Array<{ title: string }>
+  tone: FollowUpDraftTone
+}
+
+export function buildFollowUpDraftPrompt(args: FollowUpDraftArgs): string {
+  const hasNotes = args.notes && args.notes.trim().length > 0
+  const hasActionItems = args.actionItems && args.actionItems.trim().length > 0
+  const hasFollowUps = args.followUps.length > 0
+
+  const followUpLines = hasFollowUps
+    ? args.followUps.map(f => `- ${f.title}`).join('\n')
+    : null
+
+  const sections = [
+    `Person: ${args.personName}`,
+    `Meeting: ${args.meetingTitle} (${args.meetingDate})`,
+    `Tone: ${args.tone}`,
+    '',
+    hasNotes
+      ? `=== Meeting Notes ===\n${args.notes!.slice(0, 1500)}`
+      : '=== Meeting Notes ===\nNo notes recorded.',
+    '',
+    hasActionItems
+      ? `=== Action Items ===\n${args.actionItems!.slice(0, 800)}`
+      : '=== Action Items ===\nNone recorded.',
+    '',
+    followUpLines
+      ? `=== Manager Commitments (Follow-ups) ===\n${followUpLines}`
+      : '=== Manager Commitments (Follow-ups) ===\nNone recorded.',
+  ]
+
+  return truncateToTokenBudget(sections.join('\n'), 4000)
+}
+
 // ─── Action Item Extraction ───────────────────────────────────────────────────
 
 export const ACTION_ITEM_EXTRACTION_SYSTEM = `Extract action items from meeting notes. An action item is something someone committed to DO — not a discussion point or observation.

--- a/lib/services/__tests__/follow-up-draft.test.ts
+++ b/lib/services/__tests__/follow-up-draft.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for follow-up draft prompt builder.
+ * Pure function tests — no mocks needed.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  buildFollowUpDraftPrompt,
+  FOLLOW_UP_DRAFT_SYSTEM,
+  type FollowUpDraftArgs,
+  type FollowUpDraftTone,
+} from '@/lib/ai/prompts'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const BASE_ARGS: FollowUpDraftArgs = {
+  personName:   'Alice Chen',
+  meetingTitle: '1:1 with Alice',
+  meetingDate:  '2026-05-23',
+  notes:        "Discussed Q2 roadmap and Alice's promotion timeline.",
+  actionItems:  '- Alice to draft spec by Friday\n- Review PR #42',
+  followUps:    [{ title: 'Check on promo timeline' }, { title: 'Share salary band info' }],
+  tone:         'casual',
+}
+
+// ─── FOLLOW_UP_DRAFT_SYSTEM ───────────────────────────────────────────────────
+
+describe('FOLLOW_UP_DRAFT_SYSTEM', () => {
+  it('is a non-empty string', () => {
+    expect(typeof FOLLOW_UP_DRAFT_SYSTEM).toBe('string')
+    expect(FOLLOW_UP_DRAFT_SYSTEM.length).toBeGreaterThan(50)
+  })
+
+  it('mentions all three tone variants', () => {
+    expect(FOLLOW_UP_DRAFT_SYSTEM).toContain('formal')
+    expect(FOLLOW_UP_DRAFT_SYSTEM).toContain('casual')
+    expect(FOLLOW_UP_DRAFT_SYSTEM).toContain('slack')
+  })
+
+  it('instructs to keep under 200 words', () => {
+    expect(FOLLOW_UP_DRAFT_SYSTEM).toContain('200 words')
+  })
+
+  it('instructs not to fabricate', () => {
+    expect(FOLLOW_UP_DRAFT_SYSTEM.toLowerCase()).toContain('fabricate')
+  })
+})
+
+// ─── buildFollowUpDraftPrompt ─────────────────────────────────────────────────
+
+describe('buildFollowUpDraftPrompt', () => {
+  it('includes person name', () => {
+    const result = buildFollowUpDraftPrompt(BASE_ARGS)
+    expect(result).toContain('Alice Chen')
+  })
+
+  it('includes meeting title and date', () => {
+    const result = buildFollowUpDraftPrompt(BASE_ARGS)
+    expect(result).toContain('1:1 with Alice')
+    expect(result).toContain('2026-05-23')
+  })
+
+  it('includes meeting notes', () => {
+    const result = buildFollowUpDraftPrompt(BASE_ARGS)
+    expect(result).toContain('Q2 roadmap')
+    expect(result).toContain('promotion timeline')
+  })
+
+  it('includes action items', () => {
+    const result = buildFollowUpDraftPrompt(BASE_ARGS)
+    expect(result).toContain('draft spec by Friday')
+    expect(result).toContain('Review PR #42')
+  })
+
+  it('includes follow-up commitments', () => {
+    const result = buildFollowUpDraftPrompt(BASE_ARGS)
+    expect(result).toContain('Check on promo timeline')
+    expect(result).toContain('Share salary band info')
+  })
+
+  it('includes selected tone', () => {
+    const tones: FollowUpDraftTone[] = ['formal', 'casual', 'slack']
+    for (const tone of tones) {
+      const result = buildFollowUpDraftPrompt({ ...BASE_ARGS, tone })
+      expect(result).toContain(tone)
+    }
+  })
+
+  // ─── Graceful degradation ────────────────────────────────────────────────────
+
+  it('handles null notes', () => {
+    const result = buildFollowUpDraftPrompt({ ...BASE_ARGS, notes: null })
+    expect(result).toContain('No notes recorded')
+    // Should still include other data
+    expect(result).toContain('Alice Chen')
+  })
+
+  it('handles undefined notes', () => {
+    const result = buildFollowUpDraftPrompt({ ...BASE_ARGS, notes: undefined })
+    expect(result).toContain('No notes recorded')
+  })
+
+  it('handles empty string notes', () => {
+    const result = buildFollowUpDraftPrompt({ ...BASE_ARGS, notes: '' })
+    expect(result).toContain('No notes recorded')
+  })
+
+  it('handles null actionItems', () => {
+    const result = buildFollowUpDraftPrompt({ ...BASE_ARGS, actionItems: null })
+    expect(result).toContain('None recorded')
+  })
+
+  it('handles undefined actionItems', () => {
+    const result = buildFollowUpDraftPrompt({ ...BASE_ARGS, actionItems: undefined })
+    expect(result).toContain('None recorded')
+  })
+
+  it('handles empty actionItems string', () => {
+    const result = buildFollowUpDraftPrompt({ ...BASE_ARGS, actionItems: '' })
+    expect(result).toContain('None recorded')
+  })
+
+  it('handles empty followUps array', () => {
+    const result = buildFollowUpDraftPrompt({ ...BASE_ARGS, followUps: [] })
+    expect(result).toContain('None recorded')
+  })
+
+  it('handles all fields absent — still returns valid prompt', () => {
+    const result = buildFollowUpDraftPrompt({
+      personName:   'Bob Smith',
+      meetingTitle: 'Check-in',
+      meetingDate:  '2026-05-23',
+      notes:        null,
+      actionItems:  null,
+      followUps:    [],
+      tone:         'formal',
+    })
+    expect(result).toContain('Bob Smith')
+    expect(result).toContain('Check-in')
+    expect(result).toContain('formal')
+    expect(result).toContain('No notes recorded')
+    expect(result).toContain('None recorded')
+  })
+
+  // ─── Token budget ─────────────────────────────────────────────────────────────
+
+  it('stays within overall token budget even with very long inputs', () => {
+    // Notes are pre-sliced to 1500 chars and action items to 800 chars before
+    // the token budget check, so the prompt is always compact
+    const longNotes = 'x'.repeat(20000)
+    const longActions = 'y'.repeat(5000)
+    const result = buildFollowUpDraftPrompt({ ...BASE_ARGS, notes: longNotes, actionItems: longActions })
+    // 4000 token budget × 4 chars/token = 16000 chars max
+    expect(result.length).toBeLessThanOrEqual(16100)
+  })
+
+  it('does not truncate short prompts', () => {
+    const result = buildFollowUpDraftPrompt(BASE_ARGS)
+    expect(result).not.toContain('[truncated]')
+  })
+
+  // ─── Section headers ─────────────────────────────────────────────────────────
+
+  it('contains expected section headers', () => {
+    const result = buildFollowUpDraftPrompt(BASE_ARGS)
+    expect(result).toContain('=== Meeting Notes ===')
+    expect(result).toContain('=== Action Items ===')
+    expect(result).toContain('=== Manager Commitments (Follow-ups) ===')
+  })
+
+  // ─── Notes truncation at 1500 chars ──────────────────────────────────────────
+
+  it('truncates notes to 1500 chars in the prompt', () => {
+    const exactNotes = 'a'.repeat(2000)
+    const result = buildFollowUpDraftPrompt({ ...BASE_ARGS, notes: exactNotes })
+    // Notes block should not contain more than 1500 of the 'a' chars in sequence
+    const notesSection = result.split('=== Action Items ===')[0]
+    const aRun = notesSection.match(/a+/)?.[0] ?? ''
+    expect(aRun.length).toBeLessThanOrEqual(1500)
+  })
+})


### PR DESCRIPTION
Closes #107

## What

After saving a meeting with notes or action items, a dismissible banner appears offering to draft a follow-up message. The draft modal supports three tones, is editable, and provides one-click copy-to-clipboard.

## Changes

### `lib/ai/prompts.ts`
- Add `FOLLOW_UP_DRAFT_SYSTEM` — instructs the model to write a concise follow-up under 200 words, referencing specific action items and commitments
- Add `buildFollowUpDraftPrompt` — assembles person name, meeting title, date, notes, action items, and manager follow-up commitments into a structured prompt
- Add `FollowUpDraftTone` type (`formal | casual | slack`) and `FollowUpDraftArgs` interface
- Graceful degradation: all fields nullable — falls back to clear `No notes recorded` / `None recorded` labels when data is absent

### `components/follow-up-draft-modal.tsx` (new)
- Tone selector (Formal / Casual / Slack) with description tooltip
- Editable `<Textarea>` for the generated draft
- Copy-to-clipboard with transient "Copied" confirmation
- Regenerate button — available after first generation; also auto-fires when tone changes
- Loading spinner, error state with "Try again", empty state with context-aware hint
- State resets on close so next open is fresh

### `app/(dashboard)/meetings/page.tsx`
- Import `FollowUpDraftModal`
- After `handleAddMeeting` succeeds: if AI is configured and meeting has notes or action items, set `followUpDraftMeeting` and show the banner
- Banner renders at the top of the detail pane with "Draft message" / "Dismiss" buttons
- Banner auto-dismisses when the draft modal is closed

## Acceptance criteria

- [x] Draft triggered after meeting save (opt-in, not forced)
- [x] Three tone options: formal, casual, Slack
- [x] Draft references specific action items and commitments
- [x] Editable before copy
- [x] Copy-to-clipboard works
- [x] Graceful degradation when no notes/action items
- [x] Loading and error states handled

## Tests

49 new tests across two files:

| File | Tests |
|------|-------|
| `lib/services/__tests__/follow-up-draft.test.ts` | 22 — prompt builder unit tests |
| `components/__tests__/follow-up-draft-modal.test.tsx` | 27 — modal component tests |

Full suite: **577 tests, all passing**.
